### PR TITLE
Add GitHub CLI support and refactor build options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ src/
   commands/   # CLI command implementations
   config/     # Constants, tool profiles, path helpers
   docker/     # Docker client, image builder, container management
+  github/     # GitHub CLI setup script and .bashrc hook
   utils/      # Arg parsing, validation, logging, error helpers
   index.ts    # Entry point
 scripts/e2e/  # End-to-end test scripts (bash + Docker)

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ When you exit the shell, the container keeps running. Reconnect anytime with `ne
 
 | Command | Description |
 |---------|-------------|
-| `nebubox start <path> [--tool <name>] [--no-cache] [--recreate] [--github]` | Create/start container and attach shell |
+| `nebubox start <path> [--tool <name>] [--rebuild] [--github]` | Create/start container and attach shell |
 | `nebubox list [--tool <name>]` | List managed containers |
 | `nebubox stop <name>` | Stop a running container |
 | `nebubox attach <name>` | Attach to a running container |
 | `nebubox remove <name>` | Remove a container |
-| `nebubox build [<tool>] [--tool <name>] [--no-cache] [--github]` | Build or rebuild a tool's Docker image |
+| `nebubox build [<tool>] [--tool <name>] [--rebuild] [--github]` | Build or rebuild a tool's Docker image |
 
 ## Supported Tools
 
@@ -140,11 +140,13 @@ Nebubox stores each tool's credentials under `~/.nebubox/auth/<tool>/` on the ho
 - **Codex CLI** — Auth is stored in the standard `.codex` directory. Run `codex` and follow the login prompt on first use.
 - **GitHub CLI** (`--github`) — When you pass `--github`, Nebubox installs `gh` in the container image and mounts `~/.nebubox/auth/github/` for credential persistence. Run `gh auth login` on first use. Your git identity (`user.name` and `user.email`) is automatically configured from your GitHub account on the next shell session.
 
-If you need to pick up configuration changes (e.g., after updating nebubox), recreate your containers:
+If you need to pick up configuration changes (e.g., after updating nebubox), rebuild your containers:
 
 ```bash
-nebubox start ./my-project --tool claude --recreate
+nebubox start ./my-project --tool claude --rebuild
 ```
+
+Nebubox also auto-detects when `--github` has changed since the container was created and transparently recreates the container to match.
 
 ## Examples
 
@@ -152,11 +154,11 @@ nebubox start ./my-project --tool claude --recreate
 # Build the Gemini image ahead of time
 nebubox build gemini
 
-# Rebuild without Docker cache
-nebubox build claude --no-cache
+# Rebuild image and recreate container
+nebubox build claude --rebuild
 
-# Recreate container to pick up image or config changes
-nebubox start ./my-project --tool claude --recreate
+# Rebuild to pick up image or config changes
+nebubox start ./my-project --tool claude --rebuild
 
 # Enable GitHub CLI for creating PRs, pushing, etc.
 nebubox start ./my-project --tool claude --github

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ nebubox start ./my-project
 nebubox start ./my-project --tool claude
 nebubox start ./my-project --tool gemini
 nebubox start ./my-project --tool codex
+
+# Start with GitHub CLI support
+nebubox start ./my-project --tool claude --github
 ```
 
 This will:
@@ -85,12 +88,12 @@ When you exit the shell, the container keeps running. Reconnect anytime with `ne
 
 | Command | Description |
 |---------|-------------|
-| `nebubox start <path> [--tool <name>] [--no-cache] [--recreate]` | Create/start container and attach shell |
+| `nebubox start <path> [--tool <name>] [--no-cache] [--recreate] [--github]` | Create/start container and attach shell |
 | `nebubox list [--tool <name>]` | List managed containers |
 | `nebubox stop <name>` | Stop a running container |
 | `nebubox attach <name>` | Attach to a running container |
 | `nebubox remove <name>` | Remove a container |
-| `nebubox build [<tool>] [--tool <name>] [--no-cache]` | Build or rebuild a tool's Docker image |
+| `nebubox build [<tool>] [--tool <name>] [--no-cache] [--github]` | Build or rebuild a tool's Docker image |
 
 ## Supported Tools
 
@@ -125,6 +128,7 @@ Containers are named `nebubox-<tool>-<project-dir>` and labeled for easy filteri
     claude/         # Claude Code credentials & config (~/.claude)
     gemini/         # Gemini CLI credentials
     codex/          # Codex CLI credentials
+    github/         # GitHub CLI auth + .gitconfig (when --github is used)
 ```
 
 ### Auth Persistence
@@ -134,6 +138,7 @@ Nebubox stores each tool's credentials under `~/.nebubox/auth/<tool>/` on the ho
 - **Claude Code** — Nebubox sets `CLAUDE_CONFIG_DIR` to point to the mounted auth directory, so all config (`.claude.json`, `.credentials.json`, settings) lives in a single volume. This avoids [credential conflicts](https://github.com/anthropics/claude-code/issues/1414) between macOS and Linux. Run `claude login` on first use.
 - **Gemini CLI** — Auth is stored in the standard `.gemini` directory. Note that Gemini re-execs itself after login, so `NPM_CONFIG_PREFIX` is set at build-time only to avoid module resolution issues. Run `gemini` and follow the login prompt on first use.
 - **Codex CLI** — Auth is stored in the standard `.codex` directory. Run `codex` and follow the login prompt on first use.
+- **GitHub CLI** (`--github`) — When you pass `--github`, Nebubox installs `gh` in the container image and mounts `~/.nebubox/auth/github/` for credential persistence. Run `gh auth login` on first use. Your git identity (`user.name` and `user.email`) is automatically configured from your GitHub account on the next shell session.
 
 If you need to pick up configuration changes (e.g., after updating nebubox), recreate your containers:
 
@@ -152,6 +157,9 @@ nebubox build claude --no-cache
 
 # Recreate container to pick up image or config changes
 nebubox start ./my-project --tool claude --recreate
+
+# Enable GitHub CLI for creating PRs, pushing, etc.
+nebubox start ./my-project --tool claude --github
 
 # Work on two projects with Claude Code
 nebubox start ~/projects/frontend --tool claude

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,12 @@ Containers are named `nebubox-<tool>-<project-dir>` and labeled for easy filteri
     github/         # GitHub CLI auth + .gitconfig (when --github is used)
 ```
 
+## GitHub CLI Integration
+
+Pass `--github` to install [GitHub CLI](https://cli.github.com/) in the container with persistent credentials. After a one-time `gh auth login`, your git identity is automatically configured from your GitHub account, and AI tools can create PRs, push branches, and call the GitHub API from inside the sandbox.
+
+See the [Advanced section in the README](https://github.com/luixaviles/nebubox#advanced) for the full setup guide.
+
 ## Links
 
 - [GitHub Repository](https://github.com/luixaviles/nebubox)

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,9 @@ nebubox start ./my-project
 nebubox start ./my-project --tool claude
 nebubox start ./my-project --tool gemini
 nebubox start ./my-project --tool codex
+
+# Start with GitHub CLI support
+nebubox start ./my-project --tool claude --github
 ```
 
 This will:
@@ -65,6 +68,7 @@ Containers are named `nebubox-<tool>-<project-dir>` and labeled for easy filteri
     claude/         # Claude Code credentials & config
     gemini/         # Gemini CLI credentials
     codex/          # Codex CLI credentials
+    github/         # GitHub CLI auth + .gitconfig (when --github is used)
 ```
 
 ## Links

--- a/package-lock.json
+++ b/package-lock.json
@@ -552,9 +552,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -566,9 +566,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -580,9 +580,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -594,9 +594,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -608,9 +608,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -622,9 +622,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -636,9 +636,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
@@ -650,9 +650,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
@@ -664,9 +664,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
@@ -678,9 +678,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
@@ -692,9 +692,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
@@ -706,9 +706,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
       ],
@@ -720,9 +720,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
       "cpu": [
         "ppc64"
       ],
@@ -734,9 +734,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
       ],
@@ -748,9 +748,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
@@ -762,9 +762,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
@@ -776,9 +776,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
@@ -790,9 +790,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
@@ -804,9 +804,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
@@ -818,9 +818,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
       "cpu": [
         "x64"
       ],
@@ -832,9 +832,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
       ],
@@ -846,9 +846,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -860,9 +860,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -874,9 +874,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
       "cpu": [
         "x64"
       ],
@@ -888,9 +888,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -1407,9 +1407,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1423,31 +1423,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.57.1",
-        "@rollup/rollup-android-arm64": "4.57.1",
-        "@rollup/rollup-darwin-arm64": "4.57.1",
-        "@rollup/rollup-darwin-x64": "4.57.1",
-        "@rollup/rollup-freebsd-arm64": "4.57.1",
-        "@rollup/rollup-freebsd-x64": "4.57.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-        "@rollup/rollup-linux-arm64-musl": "4.57.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-        "@rollup/rollup-linux-loong64-musl": "4.57.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-musl": "4.57.1",
-        "@rollup/rollup-openbsd-x64": "4.57.1",
-        "@rollup/rollup-openharmony-arm64": "4.57.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-        "@rollup/rollup-win32-x64-gnu": "4.57.1",
-        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebubox",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Run AI coding CLI tools safely inside Docker containers",
   "type": "module",
   "bin": {

--- a/scripts/e2e/test-cli-basics.sh
+++ b/scripts/e2e/test-cli-basics.sh
@@ -68,6 +68,18 @@ assert_output_contains "remove shows usage hint" "Usage:" node dist/index.js rem
 assert_exit "no command exits 1" 1 node dist/index.js
 assert_output_contains "no command shows usage" "USAGE" node dist/index.js
 
+# Unknown flag warnings
+assert_output_contains "unknown flag warns" "Unknown flag" node dist/index.js start . --tool claude --badFlag
+assert_output_contains "unknown flag includes flag name" "--badFlag" node dist/index.js start . --tool claude --badFlag
+
+# Known flags should NOT produce unknown flag warnings
+# (--rebuild is known, output should not contain "Unknown flag")
+# We test indirectly: --help with --rebuild should not warn
+assert_exit "--help with --rebuild exits 0" 0 node dist/index.js --help --rebuild
+
+# --no-cache should warn (replaced by --rebuild)
+assert_output_contains "--no-cache warns as unknown" "Unknown flag" node dist/index.js build --tool claude --no-cache
+
 echo ""
 echo "CLI Basics: $PASS passed, $FAIL failed"
 

--- a/scripts/e2e/test-github.sh
+++ b/scripts/e2e/test-github.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASS=0
+FAIL=0
+CLEANUP_IMAGES=()
+
+cleanup() {
+  for img in "${CLEANUP_IMAGES[@]}"; do
+    docker rmi -f "$img" >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT
+
+assert_ok() {
+  local desc="$1"
+  shift
+  set +e
+  "$@" >/dev/null 2>&1
+  local rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (exit $rc)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_output_contains() {
+  local desc="$1" pattern="$2"
+  shift 2
+  set +e
+  local output
+  output=$("$@" 2>&1)
+  set -e
+  if echo "$output" | grep -q "$pattern"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (pattern '$pattern' not found)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== GitHub CLI Integration Tests ==="
+
+# Verify Docker is available
+if ! docker info >/dev/null 2>&1; then
+  echo "SKIP: Docker not available"
+  exit 0
+fi
+
+TOOL="codex"
+IMAGE_NAME="nebubox-${TOOL}-github:latest"
+CLEANUP_IMAGES+=("$IMAGE_NAME")
+
+# ── Build with --github ─────────────────────────────
+
+echo "  Building ${TOOL} image with --github (this may take a while)..."
+assert_ok "build ${TOOL} --github image via CLI" node dist/index.js build --tool "$TOOL" --github
+
+# Verify image exists
+assert_ok "github image exists after build" docker image inspect "$IMAGE_NAME"
+
+# ── Verify gh CLI is installed ──────────────────────
+
+assert_ok "gh is installed" \
+  docker run --rm "$IMAGE_NAME" -c "gh --version"
+
+assert_output_contains "gh --version reports gh" "gh version" \
+  docker run --rm "$IMAGE_NAME" -c "gh --version"
+
+# ── Verify setup script is installed ────────────────
+
+assert_ok "nebubox-gh-setup exists and is executable" \
+  docker run --rm "$IMAGE_NAME" -c "test -x /usr/local/bin/nebubox-gh-setup"
+
+assert_output_contains "nebubox-gh-setup contains auth check" "gh auth status" \
+  docker run --rm "$IMAGE_NAME" -c "cat /usr/local/bin/nebubox-gh-setup"
+
+# ── Verify .bashrc hook ────────────────────────────
+
+assert_output_contains ".bashrc contains gh auto-setup hook" "nebubox-gh-setup" \
+  docker run --rm "$IMAGE_NAME" -c "cat /home/coder/.bashrc"
+
+echo ""
+echo "GitHub CLI Integration: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -6,6 +6,7 @@ import * as log from '../utils/logger.js';
 export interface BuildOptions {
   tool: string;
   noCache: boolean;
+  github: boolean;
 }
 
 export async function buildCommand(opts: BuildOptions): Promise<void> {
@@ -14,9 +15,11 @@ export async function buildCommand(opts: BuildOptions): Promise<void> {
 
   const profile = getToolProfile(opts.tool)!;
 
-  if (imageExists(profile.name)) {
-    log.info(`Image ${getImageName(profile.name)} already exists. Rebuilding...`);
+  const imageOpts = opts.github ? { github: true } : undefined;
+
+  if (imageExists(profile.name, opts.github)) {
+    log.info(`Image ${getImageName(profile.name, opts.github)} already exists. Rebuilding...`);
   }
 
-  await buildImage(profile, opts.noCache);
+  await buildImage(profile, opts.noCache, imageOpts);
 }

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -5,7 +5,7 @@ import * as log from '../utils/logger.js';
 
 export interface BuildOptions {
   tool: string;
-  noCache: boolean;
+  rebuild: boolean;
   github: boolean;
 }
 
@@ -21,5 +21,5 @@ export async function buildCommand(opts: BuildOptions): Promise<void> {
     log.info(`Image ${getImageName(profile.name, opts.github)} already exists. Rebuilding...`);
   }
 
-  await buildImage(profile, opts.noCache, imageOpts);
+  await buildImage(profile, opts.rebuild, imageOpts);
 }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -2,6 +2,7 @@ export const LABEL_MANAGED = 'nebubox.managed';
 export const LABEL_TOOL = 'nebubox.tool';
 export const LABEL_PROJECT = 'nebubox.project';
 export const LABEL_PROJECT_PATH = 'nebubox.project-path';
+export const LABEL_GITHUB = 'nebubox.github';
 
 export const IMAGE_PREFIX = 'nebubox-';
 export const CONTAINER_PREFIX = 'nebubox-';

--- a/src/docker/container.test.ts
+++ b/src/docker/container.test.ts
@@ -178,14 +178,14 @@ describe('createContainer per provider', () => {
 });
 
 describe('createContainer with github', () => {
-  it('adds 2 extra volume mounts for github auth and gitconfig', () => {
+  it('adds 1 extra volume mount for github auth dir', () => {
     vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: 'abc', stderr: '' });
     createContainer(mockProfile, '/home/user/proj', { github: true });
 
     const args = vi.mocked(dockerExec).mock.calls[0][0];
     const vCount = args.filter((a: string) => a === '-v').length;
-    // project + authDir + github auth + gitconfig = 4
-    const expected = 2 + mockProfile.authFiles.length + 2;
+    // project + authDir + github auth dir = 3
+    const expected = 2 + mockProfile.authFiles.length + 1;
     expect(vCount).toBe(expected);
   });
 
@@ -197,16 +197,6 @@ describe('createContainer with github', () => {
     const vArgs = args.filter((_: string, i: number) => args[i - 1] === '-v');
     const ghMount = vArgs.find((v: string) => v.includes(`${CODER_HOME}/.config/gh`));
     expect(ghMount).toBeDefined();
-  });
-
-  it('mounts .gitconfig to /home/coder/.gitconfig', () => {
-    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: 'abc', stderr: '' });
-    createContainer(mockProfile, '/home/user/proj', { github: true });
-
-    const args = vi.mocked(dockerExec).mock.calls[0][0];
-    const vArgs = args.filter((_: string, i: number) => args[i - 1] === '-v');
-    const gitconfigMount = vArgs.find((v: string) => v.includes(`${CODER_HOME}/.gitconfig`));
-    expect(gitconfigMount).toBeDefined();
   });
 
   it('uses github image name', () => {

--- a/src/docker/container.ts
+++ b/src/docker/container.ts
@@ -95,16 +95,18 @@ export function createContainer(
     createArgs.push('-v', `${hostFile}:${containerFile}`);
   }
 
-  // GitHub CLI: mount gh config dir and .gitconfig
+  // GitHub CLI: mount gh config dir (contains .gitconfig too)
   if (github) {
     const ghAuthDir = ensureAuthDir('github');
     createArgs.push('-v', `${ghAuthDir}:${CODER_HOME}/.config/gh`);
 
+    // Ensure .gitconfig exists inside the mounted dir so git can find it.
+    // GIT_CONFIG_GLOBAL (set in the image) points here, avoiding a
+    // file bind mount which breaks git's atomic write pattern.
     const gitconfigPath = join(ghAuthDir, '.gitconfig');
     if (!existsSync(gitconfigPath)) {
       writeFileSync(gitconfigPath, '');
     }
-    createArgs.push('-v', `${gitconfigPath}:${CODER_HOME}/.gitconfig`);
   }
 
   createArgs.push('-w', WORKSPACE_DIR, imageName);

--- a/src/docker/image.test.ts
+++ b/src/docker/image.test.ts
@@ -126,10 +126,20 @@ describe('generateDockerfile with github', () => {
     expect(copyIndex).toBeLessThan(userIndex);
   });
 
+  it('sets GIT_CONFIG_GLOBAL after USER coder', () => {
+    const df = generateDockerfile(mockProfile, { github: true });
+    const userIndex = df.indexOf(`USER ${CODER_USER}`);
+    const envIndex = df.indexOf('GIT_CONFIG_GLOBAL=');
+    expect(envIndex).toBeGreaterThan(-1);
+    expect(envIndex).toBeGreaterThan(userIndex);
+    expect(df).toContain(`GIT_CONFIG_GLOBAL="${CODER_HOME}/.config/gh/.gitconfig"`);
+  });
+
   it('does not include gh install when github is not set', () => {
     const df = generateDockerfile(mockProfile);
     expect(df).not.toContain('githubcli-archive-keyring.gpg');
     expect(df).not.toContain('COPY nebubox-gh-setup');
+    expect(df).not.toContain('GIT_CONFIG_GLOBAL');
   });
 });
 

--- a/src/docker/image.test.ts
+++ b/src/docker/image.test.ts
@@ -27,6 +27,14 @@ describe('getImageName', () => {
     expect(getImageName('claude')).toBe(`${IMAGE_PREFIX}claude:latest`);
     expect(getImageName('gemini')).toBe(`${IMAGE_PREFIX}gemini:latest`);
   });
+
+  it('appends -github suffix when github is true', () => {
+    expect(getImageName('claude', true)).toBe(`${IMAGE_PREFIX}claude-github:latest`);
+  });
+
+  it('does not append suffix when github is false', () => {
+    expect(getImageName('claude', false)).toBe(`${IMAGE_PREFIX}claude:latest`);
+  });
 });
 
 describe('generateDockerfile', () => {
@@ -83,6 +91,45 @@ describe('generateDockerfile', () => {
     const df = generateDockerfile(bare);
     expect(df).toContain(`FROM ${BASE_IMAGE}`);
     expect(df).toContain('ENTRYPOINT ["/bin/bash"]');
+  });
+});
+
+describe('generateDockerfile with github', () => {
+  it('includes gh CLI install block when github is true', () => {
+    const df = generateDockerfile(mockProfile, { github: true });
+    expect(df).toContain('/etc/apt/keyrings/githubcli-archive-keyring.gpg');
+    expect(df).toContain('apt-get install -y --no-install-recommends gh');
+  });
+
+  it('includes COPY nebubox-gh-setup before USER coder', () => {
+    const df = generateDockerfile(mockProfile, { github: true });
+    const copyIndex = df.indexOf('COPY nebubox-gh-setup');
+    const userIndex = df.indexOf(`USER ${CODER_USER}`);
+    expect(copyIndex).toBeGreaterThan(-1);
+    expect(userIndex).toBeGreaterThan(-1);
+    expect(copyIndex).toBeLessThan(userIndex);
+  });
+
+  it('appends bashrc hook after USER coder', () => {
+    const df = generateDockerfile(mockProfile, { github: true });
+    const userIndex = df.indexOf(`USER ${CODER_USER}`);
+    const hookIndex = df.indexOf('cat /tmp/nebubox-bashrc-hook');
+    expect(hookIndex).toBeGreaterThan(-1);
+    expect(hookIndex).toBeGreaterThan(userIndex);
+  });
+
+  it('copies bashrc hook file before USER coder', () => {
+    const df = generateDockerfile(mockProfile, { github: true });
+    const copyIndex = df.indexOf('COPY nebubox-bashrc-hook');
+    const userIndex = df.indexOf(`USER ${CODER_USER}`);
+    expect(copyIndex).toBeGreaterThan(-1);
+    expect(copyIndex).toBeLessThan(userIndex);
+  });
+
+  it('does not include gh install when github is not set', () => {
+    const df = generateDockerfile(mockProfile);
+    expect(df).not.toContain('githubcli-archive-keyring.gpg');
+    expect(df).not.toContain('COPY nebubox-gh-setup');
   });
 });
 

--- a/src/docker/image.ts
+++ b/src/docker/image.ts
@@ -15,13 +15,20 @@ import {
 import { dockerExec, dockerExecAsync } from './client.js';
 import { ImageBuildError } from '../utils/errors.js';
 import { Spinner } from '../utils/spinner.js';
+import { GH_SETUP_SCRIPT, GH_BASHRC_HOOK } from '../github/setup-script.js';
 
-export function getImageName(toolName: string): string {
-  return `${IMAGE_PREFIX}${toolName}:latest`;
+export interface ImageOptions {
+  github?: boolean;
 }
 
-export function generateDockerfile(profile: ToolProfile): string {
+export function getImageName(toolName: string, github?: boolean): string {
+  const suffix = github ? '-github' : '';
+  return `${IMAGE_PREFIX}${toolName}${suffix}:latest`;
+}
+
+export function generateDockerfile(profile: ToolProfile, options?: ImageOptions): string {
   const lines: string[] = [];
+  const github = options?.github ?? false;
 
   lines.push(`FROM ${BASE_IMAGE}`);
   lines.push('');
@@ -32,6 +39,23 @@ export function generateDockerfile(profile: ToolProfile): string {
   lines.push(`    ${allPackages.join(' ')} \\`);
   lines.push('    && rm -rf /var/lib/apt/lists/*');
   lines.push('');
+
+  // GitHub CLI install (must run as root, before USER coder)
+  if (github) {
+    lines.push('RUN mkdir -p -m 755 /etc/apt/keyrings \\');
+    lines.push('    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \\');
+    lines.push('      -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \\');
+    lines.push('    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \\');
+    lines.push('    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \\');
+    lines.push('      > /etc/apt/sources.list.d/github-cli.list \\');
+    lines.push('    && apt-get update && apt-get install -y --no-install-recommends gh \\');
+    lines.push('    && rm -rf /var/lib/apt/lists/*');
+    lines.push('');
+    lines.push('COPY nebubox-gh-setup /usr/local/bin/nebubox-gh-setup');
+    lines.push('RUN chmod +x /usr/local/bin/nebubox-gh-setup');
+    lines.push('COPY nebubox-bashrc-hook /tmp/nebubox-bashrc-hook');
+    lines.push('');
+  }
 
   // Non-root user (handles pre-existing GID/UID in base image)
   lines.push(`RUN groupadd --gid ${CODER_GID} ${CODER_USER} 2>/dev/null || true \\`);
@@ -66,6 +90,12 @@ export function generateDockerfile(profile: ToolProfile): string {
     lines.push('');
   }
 
+  // GitHub .bashrc hook (runs as coder user)
+  if (github) {
+    lines.push(`RUN cat /tmp/nebubox-bashrc-hook >> ${CODER_HOME}/.bashrc`);
+    lines.push('');
+  }
+
   // Workspace
   lines.push(`RUN mkdir -p ${WORKSPACE_DIR}`);
   lines.push(`WORKDIR ${WORKSPACE_DIR}`);
@@ -77,21 +107,28 @@ export function generateDockerfile(profile: ToolProfile): string {
   return lines.join('\n');
 }
 
-export function imageExists(toolName: string): boolean {
-  const imageName = getImageName(toolName);
+export function imageExists(toolName: string, github?: boolean): boolean {
+  const imageName = getImageName(toolName, github);
   const result = dockerExec(['image', 'inspect', imageName]);
   return result.status === 0;
 }
 
-export async function buildImage(profile: ToolProfile, noCache = false): Promise<void> {
-  const imageName = getImageName(profile.name);
-  const dockerfile = generateDockerfile(profile);
+export async function buildImage(profile: ToolProfile, noCache = false, options?: ImageOptions): Promise<void> {
+  const github = options?.github ?? false;
+  const imageName = getImageName(profile.name, github);
+  const dockerfile = generateDockerfile(profile, options);
 
   const tmpDir = mkdtempSync(join(tmpdir(), 'nebubox-'));
 
   try {
     const dockerfilePath = join(tmpDir, 'Dockerfile');
     writeFileSync(dockerfilePath, dockerfile);
+
+    // Write gh files into the build context so COPY can find them
+    if (github) {
+      writeFileSync(join(tmpDir, 'nebubox-gh-setup'), GH_SETUP_SCRIPT);
+      writeFileSync(join(tmpDir, 'nebubox-bashrc-hook'), GH_BASHRC_HOOK);
+    }
 
     const spinner = new Spinner();
     spinner.start(`Building image ${imageName}... (this may take a few minutes)`);

--- a/src/docker/image.ts
+++ b/src/docker/image.ts
@@ -68,6 +68,15 @@ export function generateDockerfile(profile: ToolProfile, options?: ImageOptions)
   lines.push(`WORKDIR ${CODER_HOME}`);
   lines.push('');
 
+  // Point git at a config file inside the mounted gh dir so that
+  // git config --global writes survive container restarts.  Using an
+  // env var avoids a file bind mount on ~/.gitconfig which breaks
+  // git's atomic write (rename) pattern ("Device or resource busy").
+  if (github) {
+    lines.push(`ENV GIT_CONFIG_GLOBAL="${CODER_HOME}/.config/gh/.gitconfig"`);
+    lines.push('');
+  }
+
   // Configure npm global installs under home directory.
   // Use ARG (not ENV) for NPM_CONFIG_PREFIX so it is available at build time
   // but NOT at runtime — some tools (e.g. Gemini CLI) re-exec themselves after

--- a/src/github/setup-script.ts
+++ b/src/github/setup-script.ts
@@ -1,0 +1,52 @@
+/**
+ * Bash script installed as /usr/local/bin/nebubox-gh-setup.
+ * After `gh auth login`, it configures the git credential helper
+ * and sets git user.name / user.email from the GitHub account.
+ */
+export const GH_SETUP_SCRIPT = `#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify gh is authenticated
+if ! gh auth status >/dev/null 2>&1; then
+  echo "nebubox-gh-setup: gh is not authenticated — skipping git config."
+  exit 0
+fi
+
+# Install GitHub credential helper
+gh auth setup-git
+
+# Fetch name from GitHub profile
+name="$(gh api user --jq '.name // .login' 2>/dev/null || true)"
+if [ -n "$name" ]; then
+  git config --global user.name "$name"
+fi
+
+# Fetch primary email (requires read:user or user:email scope)
+email="$(gh api user/emails --jq '[.[] | select(.primary)] | .[0].email // empty' 2>/dev/null || true)"
+if [ -n "$email" ]; then
+  git config --global user.email "$email"
+fi
+
+if [ -n "$name" ] || [ -n "$email" ]; then
+  echo "nebubox-gh-setup: git configured as $name <$email>"
+  echo "  Override with: git config --global user.name 'Your Name'"
+else
+  echo "nebubox-gh-setup: could not fetch GitHub profile info. Set git identity manually:"
+  echo "  git config --global user.name 'Your Name'"
+  echo "  git config --global user.email 'you@example.com'"
+fi
+`;
+
+/**
+ * Snippet appended to the coder user's .bashrc.
+ * Runs nebubox-gh-setup once per shell when gh is authenticated
+ * but git user.name has not been configured yet.
+ */
+export const GH_BASHRC_HOOK = `
+# nebubox: auto-configure git identity from GitHub
+if command -v gh >/dev/null 2>&1 \\
+   && gh auth status >/dev/null 2>&1 \\
+   && [ -z "$(git config --global user.name 2>/dev/null)" ]; then
+  nebubox-gh-setup
+fi
+`;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const CLI = resolve(import.meta.dirname, '..', 'dist', 'index.js');
+
+function run(...args: string[]): string {
+  try {
+    return execFileSync('node', [CLI, ...args], {
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+  } catch (err: any) {
+    // CLI may exit non-zero; we still want stdout+stderr
+    return (err.stdout ?? '') + (err.stderr ?? '');
+  }
+}
+
+describe('unknown flag warnings', () => {
+  it('warns about unknown flags', () => {
+    const output = run('start', '.', '--tool', 'claude', '--badFlag');
+    expect(output).toContain('Unknown flag');
+    expect(output).toContain('--badFlag');
+  });
+
+  it('does not warn about known flags', () => {
+    const output = run('--help');
+    expect(output).not.toContain('Unknown flag');
+  });
+
+  it('does not warn about --rebuild', () => {
+    // --rebuild is known, so no warning (will fail on Docker check but that's fine)
+    const output = run('build', '--tool', 'claude', '--rebuild');
+    expect(output).not.toContain('Unknown flag');
+  });
+
+  it('does not warn about --github', () => {
+    const output = run('--help', '--github');
+    expect(output).not.toContain('Unknown flag');
+  });
+
+  it('warns about --no-cache (replaced by --rebuild)', () => {
+    const output = run('build', '--tool', 'claude', '--no-cache');
+    expect(output).toContain('Unknown flag');
+    expect(output).toContain('--no-cache');
+  });
+
+  it('warns about --recreate (replaced by --rebuild)', () => {
+    const output = run('start', '.', '--tool', 'claude', '--recreate');
+    expect(output).toContain('Unknown flag');
+    expect(output).toContain('--recreate');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,10 @@ import { parseArgs } from './utils/parse-args.js';
 const VERSION = '0.1.0';
 process.title = `nebubox v${VERSION}`;
 
+const KNOWN_FLAGS = new Set([
+  'tool', 'rebuild', 'github', 'help', 'h', 'version', 'v',
+]);
+
 function printHelp(): void {
   const tools = getToolNames().join(', ');
   console.log(`
@@ -25,18 +29,17 @@ USAGE
   nebubox <command> [options]
 
 COMMANDS
-  start <path> [--tool <name>] [--no-cache] [--recreate] [--github]   Create/start container and attach shell
+  start <path> [--tool <name>] [--rebuild] [--github]   Create/start container and attach shell
   list [--tool <name>]           List managed containers
   stop <name>                    Stop a running container
   attach <name>                  Attach to a running container
   remove <name>                  Remove a container
-  build [<tool>] [--tool <name>] [--no-cache] [--github]   Build (or rebuild) a tool's Docker image
+  build [<tool>] [--tool <name>] [--rebuild] [--github]   Build (or rebuild) a tool's Docker image
 
 OPTIONS
   --tool <name>    Tool to use (interactive prompt if omitted)
                    Available: ${tools}
-  --no-cache       Skip Docker cache when building images
-  --recreate       Remove and recreate existing container
+  --rebuild        Rebuild image (no Docker cache) and recreate container
   --github         Install GitHub CLI and persist auth across sessions
   --help, -h       Show this help message
   --version, -v    Show version
@@ -54,6 +57,14 @@ EXAMPLES
 `);
 }
 
+function warnUnknownFlags(flags: Record<string, string>): void {
+  for (const key of Object.keys(flags)) {
+    if (!KNOWN_FLAGS.has(key)) {
+      log.warn(`Unknown flag: --${key} (ignored)`);
+    }
+  }
+}
+
 async function main(): Promise<void> {
   const { command, args, flags } = parseArgs(process.argv);
 
@@ -66,6 +77,8 @@ async function main(): Promise<void> {
     console.log(`nebubox v${VERSION}`);
     return;
   }
+
+  warnUnknownFlags(flags);
 
   if (!command) {
     printHelp();
@@ -82,7 +95,7 @@ async function main(): Promise<void> {
           process.exit(1);
         }
         const startTool = flags['tool'] ?? await promptToolSelection();
-        await startCommand({ path, tool: startTool, noCache: flags['no-cache'] === 'true', recreate: flags['recreate'] === 'true', github: flags['github'] === 'true' });
+        await startCommand({ path, tool: startTool, rebuild: flags['rebuild'] === 'true', github: flags['github'] === 'true' });
         break;
       }
 
@@ -126,7 +139,7 @@ async function main(): Promise<void> {
 
       case 'build': {
         const buildTool = args[0] ?? flags['tool'] ?? await promptToolSelection();
-        await buildCommand({ tool: buildTool, noCache: flags['no-cache'] === 'true', github: flags['github'] === 'true' });
+        await buildCommand({ tool: buildTool, rebuild: flags['rebuild'] === 'true', github: flags['github'] === 'true' });
         break;
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,24 +25,26 @@ USAGE
   nebubox <command> [options]
 
 COMMANDS
-  start <path> [--tool <name>] [--no-cache] [--recreate]   Create/start container and attach shell
+  start <path> [--tool <name>] [--no-cache] [--recreate] [--github]   Create/start container and attach shell
   list [--tool <name>]           List managed containers
   stop <name>                    Stop a running container
   attach <name>                  Attach to a running container
   remove <name>                  Remove a container
-  build [<tool>] [--tool <name>] [--no-cache]   Build (or rebuild) a tool's Docker image
+  build [<tool>] [--tool <name>] [--no-cache] [--github]   Build (or rebuild) a tool's Docker image
 
 OPTIONS
   --tool <name>    Tool to use (interactive prompt if omitted)
                    Available: ${tools}
   --no-cache       Skip Docker cache when building images
   --recreate       Remove and recreate existing container
+  --github         Install GitHub CLI and persist auth across sessions
   --help, -h       Show this help message
   --version, -v    Show version
 
 EXAMPLES
   nebubox start ./my-project
   nebubox start ./my-project --tool gemini
+  nebubox start ./my-project --tool claude --github
   nebubox list
   nebubox list --tool claude
   nebubox stop nebubox-claude-my-project
@@ -80,7 +82,7 @@ async function main(): Promise<void> {
           process.exit(1);
         }
         const startTool = flags['tool'] ?? await promptToolSelection();
-        await startCommand({ path, tool: startTool, noCache: flags['no-cache'] === 'true', recreate: flags['recreate'] === 'true' });
+        await startCommand({ path, tool: startTool, noCache: flags['no-cache'] === 'true', recreate: flags['recreate'] === 'true', github: flags['github'] === 'true' });
         break;
       }
 
@@ -124,7 +126,7 @@ async function main(): Promise<void> {
 
       case 'build': {
         const buildTool = args[0] ?? flags['tool'] ?? await promptToolSelection();
-        await buildCommand({ tool: buildTool, noCache: flags['no-cache'] === 'true' });
+        await buildCommand({ tool: buildTool, noCache: flags['no-cache'] === 'true', github: flags['github'] === 'true' });
         break;
       }
 

--- a/src/utils/parse-args.test.ts
+++ b/src/utils/parse-args.test.ts
@@ -25,20 +25,20 @@ describe('parseArgs', () => {
   });
 
   it('parses boolean flags (no value)', () => {
-    const result = parseArgs(['node', 'nebubox', 'build', '--no-cache']);
-    expect(result.flags['no-cache']).toBe('true');
+    const result = parseArgs(['node', 'nebubox', 'build', '--rebuild']);
+    expect(result.flags['rebuild']).toBe('true');
   });
 
   it('parses mixed positional args and flags', () => {
-    const result = parseArgs(['node', 'nebubox', 'start', './proj', '--tool', 'gemini', '--no-cache']);
+    const result = parseArgs(['node', 'nebubox', 'start', './proj', '--tool', 'gemini', '--rebuild']);
     expect(result.command).toBe('start');
     expect(result.args).toEqual(['./proj']);
-    expect(result.flags).toEqual({ tool: 'gemini', 'no-cache': 'true' });
+    expect(result.flags).toEqual({ tool: 'gemini', 'rebuild': 'true' });
   });
 
   it('treats flag followed by another flag as boolean', () => {
-    const result = parseArgs(['node', 'nebubox', 'build', '--no-cache', '--tool', 'codex']);
-    expect(result.flags['no-cache']).toBe('true');
+    const result = parseArgs(['node', 'nebubox', 'build', '--rebuild', '--tool', 'codex']);
+    expect(result.flags['rebuild']).toBe('true');
     expect(result.flags['tool']).toBe('codex');
   });
 
@@ -54,9 +54,9 @@ describe('parseArgs', () => {
   });
 
   it('parses --github alongside other flags', () => {
-    const result = parseArgs(['node', 'nebubox', 'start', './proj', '--github', '--no-cache', '--tool', 'claude']);
+    const result = parseArgs(['node', 'nebubox', 'start', './proj', '--github', '--rebuild', '--tool', 'claude']);
     expect(result.flags['github']).toBe('true');
-    expect(result.flags['no-cache']).toBe('true');
+    expect(result.flags['rebuild']).toBe('true');
     expect(result.flags['tool']).toBe('claude');
   });
 });

--- a/src/utils/parse-args.test.ts
+++ b/src/utils/parse-args.test.ts
@@ -47,4 +47,16 @@ describe('parseArgs', () => {
     expect(result.command).toBe('start');
     expect(result.args).toEqual(['a', 'b', 'c']);
   });
+
+  it('parses --github as a boolean flag', () => {
+    const result = parseArgs(['node', 'nebubox', 'start', './proj', '--tool', 'claude', '--github']);
+    expect(result.flags['github']).toBe('true');
+  });
+
+  it('parses --github alongside other flags', () => {
+    const result = parseArgs(['node', 'nebubox', 'start', './proj', '--github', '--no-cache', '--tool', 'claude']);
+    expect(result.flags['github']).toBe('true');
+    expect(result.flags['no-cache']).toBe('true');
+    expect(result.flags['tool']).toBe('claude');
+  });
 });


### PR DESCRIPTION
## Summary
- Add GitHub CLI (`gh`) integration with authentication and credential persistence
- Replace `--no-cache` and `--recreate` flags with a unified `--rebuild` option
- Add unknown flag warnings for better user feedback
- Enhance GitHub setup script with robust user profile detection
- Add comprehensive tests and documentation for new features

## Test plan
- [x] Unit tests added for new CLI options and GitHub setup
- [x] E2E test script for GitHub integration (`test-github.sh`)
- [x] Manual verification of `--rebuild` flag behavior
- [x] Manual verification of GitHub CLI auth flow inside container

🤖 Generated with [Claude Code](https://claude.com/claude-code)