### PR TITLE
Separate container names for --github and non---github sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Each tool has a **profile** that defines its install method, auth directory, and
 - **Project** — `<your-project>` → `/home/coder/workspace`
 - **Auth** — `~/.nebubox/auth/<tool>/` → tool's config directory in the container
 
-Containers are named `nebubox-<tool>-<project-dir>` and labeled for easy filtering.
+Containers are named `nebubox-<tool>-<project-dir>` (or `nebubox-<tool>-<project-dir>-github` when `--github` is used) and labeled for easy filtering.
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/luixaviles/nebubox/main/docs/assets/nebubox-architecture.svg" alt="Nebubox Architecture" width="720" />
@@ -145,8 +145,6 @@ If you need to pick up configuration changes (e.g., after updating nebubox), reb
 ```bash
 nebubox start ./my-project --tool claude --rebuild
 ```
-
-Nebubox also auto-detects when `--github` has changed since the container was created and transparently recreates the container to match.
 
 ## Examples
 
@@ -208,7 +206,7 @@ gh auth login
 # 3. Exit and re-attach (or open a new shell) —
 #    git identity is automatically configured
 exit
-nebubox attach nebubox-claude-github-my-project
+nebubox attach nebubox-claude-my-project-github
 ```
 
 After the initial `gh auth login`, credentials persist on the host at `~/.nebubox/auth/github/`. All future containers started with `--github` reuse them automatically — no repeated login needed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ Each tool has a **profile** that defines its install method, auth directory, and
 - **Project** — `<your-project>` → `/home/coder/workspace`
 - **Auth** — `~/.nebubox/auth/<tool>/` → tool's config directory in the container
 
-Containers are named `nebubox-<tool>-<project-dir>` and labeled for easy filtering.
+Containers are named `nebubox-<tool>-<project-dir>` (or `nebubox-<tool>-<project-dir>-github` when `--github` is used) and labeled for easy filtering.
 
 ### Directory Layout on Host
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebubox",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Run AI coding CLI tools safely inside Docker containers",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,7 @@ EXAMPLES
   nebubox list
   nebubox list --tool claude
   nebubox stop nebubox-claude-my-project
+  nebubox stop nebubox-claude-my-project-github
   nebubox attach nebubox-claude-my-project
   nebubox remove nebubox-claude-my-project
   nebubox build --tool codex

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import * as log from './utils/logger.js';
 import { promptToolSelection } from './utils/prompt.js';
 import { parseArgs } from './utils/parse-args.js';
 
-const VERSION = '0.1.0';
+const VERSION = '0.2.1';
 
 const KNOWN_FLAGS = new Set([
   'tool', 'rebuild', 'github', 'help', 'h', 'version', 'v',

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -28,15 +28,17 @@ export function listCommand(opts: ListOptions): void {
     padRight('NAME', 40) +
     padRight('STATUS', 25) +
     padRight('TOOL', 12) +
+    padRight('GITHUB', 10) +
     'PROJECT',
   );
-  console.log('-'.repeat(90));
+  console.log('-'.repeat(100));
 
   for (const c of containers) {
     console.log(
       padRight(c.name, 40) +
       padRight(c.status, 25) +
       padRight(c.tool, 12) +
+      padRight(c.github === 'true' ? 'yes' : 'no', 10) +
       c.project,
     );
   }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -29,7 +29,7 @@ export async function startCommand(opts: StartOptions): Promise<void> {
   ensureDocker();
 
   const profile = getToolProfile(opts.tool)!;
-  const containerName = getContainerName(profile.name, projectPath);
+  const containerName = getContainerName(profile.name, projectPath, opts.github);
 
   const imageOpts = opts.github ? { github: true } : undefined;
 
@@ -53,20 +53,6 @@ export async function startCommand(opts: StartOptions): Promise<void> {
 
   // Check if container already exists
   let existing = containerExists(containerName);
-
-  // Auto-detect config drift: if --github changed since the container was
-  // created, transparently recreate to match the new options.
-  if (existing) {
-    const containerGithub = existing.github === 'true';
-    if (containerGithub !== opts.github) {
-      log.info('Recreating container to match new options...');
-      if (isContainerRunning(containerName)) {
-        stopContainer(containerName);
-      }
-      removeContainer(containerName);
-      existing = null;
-    }
-  }
 
   if (existing) {
     if (isContainerRunning(containerName)) {

--- a/src/docker/container.test.ts
+++ b/src/docker/container.test.ts
@@ -59,6 +59,18 @@ describe('getContainerName', () => {
   it('uses only the basename of the path', () => {
     expect(getContainerName('gemini', '/a/b/c/deep-project')).toBe(`${CONTAINER_PREFIX}gemini-deep-project`);
   });
+
+  it('appends -github suffix when github is true', () => {
+    expect(getContainerName('claude', '/home/user/my-project', true)).toBe(`${CONTAINER_PREFIX}claude-my-project-github`);
+  });
+
+  it('does not append suffix when github is false', () => {
+    expect(getContainerName('claude', '/home/user/my-project', false)).toBe(`${CONTAINER_PREFIX}claude-my-project`);
+  });
+
+  it('does not append suffix when github is undefined', () => {
+    expect(getContainerName('claude', '/home/user/my-project', undefined)).toBe(`${CONTAINER_PREFIX}claude-my-project`);
+  });
 });
 
 describe('containerExists', () => {
@@ -223,6 +235,17 @@ describe('createContainer with github', () => {
     const vArgs = args.filter((_: string, i: number) => args[i - 1] === '-v');
     const ghMount = vArgs.find((v: string) => v.includes(`${CODER_HOME}/.config/gh`));
     expect(ghMount).toBeDefined();
+  });
+
+  it('uses github-suffixed container name', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: 'abc', stderr: '' });
+    const name = createContainer(mockProfile, '/home/user/proj', { github: true });
+    expect(name).toBe(`${CONTAINER_PREFIX}claude-proj-github`);
+
+    const args = vi.mocked(dockerExec).mock.calls[0][0];
+    expect(args).toContain(`${CONTAINER_PREFIX}claude-proj-github`);
+    const nameIdx = args.indexOf('--name');
+    expect(args[nameIdx + 1]).toBe(`${CONTAINER_PREFIX}claude-proj-github`);
   });
 
   it('uses github image name', () => {

--- a/src/docker/container.ts
+++ b/src/docker/container.ts
@@ -29,9 +29,10 @@ export interface ContainerInfo {
   github: string;
 }
 
-export function getContainerName(toolName: string, projectPath: string): string {
+export function getContainerName(toolName: string, projectPath: string, github?: boolean): string {
   const projectBasename = basename(projectPath);
-  return `${CONTAINER_PREFIX}${toolName}-${projectBasename}`;
+  const suffix = github ? '-github' : '';
+  return `${CONTAINER_PREFIX}${toolName}-${projectBasename}${suffix}`;
 }
 
 export function containerExists(name: string): ContainerInfo | null {
@@ -74,7 +75,7 @@ export function createContainer(
   options?: ContainerOptions,
 ): string {
   const github = options?.github ?? false;
-  const name = getContainerName(profile.name, projectPath);
+  const name = getContainerName(profile.name, projectPath, github);
   const imageName = getImageName(profile.name, github);
   const hostAuthDir = ensureAuthDir(profile.name);
   const containerAuthDir = `${CODER_HOME}/${profile.authDir}`;


### PR DESCRIPTION
## Summary
- Give `--github` sessions their own container name (`nebubox-<tool>-<project>-github`) instead of reusing the same container and auto-recreating on config drift
- Remove the config drift detection/recreation logic in `start.ts` — no longer needed since each mode has a separate container
- Add a `GITHUB` column to `nebubox list` output for visibility

## Test plan
- [x] All 147 existing tests pass
- [x] New unit tests cover `getContainerName` with `github=true/false/undefined` and `createContainer` with github-suffixed name
- [x] Manual: run `nebubox start ./proj --tool claude` and `nebubox start ./proj --tool claude --github` — verify two separate containers are created
- [x] Manual: `nebubox list` shows the GITHUB column

🤖 Generated with [Claude Code](https://claude.com/claude-code)