### PR TITLE
Add pnpm support via --pnpm flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Running AI coding tools with full permissions is powerful but risky: a single ba
 - **Auth persistence** — credentials survive across container restarts via shared host directories
 - **Zero runtime dependencies** — just Node.js and Docker
 - **Non-root containers** — runs as `coder` user (UID 1000) with passwordless sudo
+- **pnpm support** — optional `--pnpm` flag installs pnpm via corepack
 
 ## Prerequisites
 
@@ -74,6 +75,9 @@ nebubox start ./my-project --tool codex
 
 # Start with GitHub CLI support
 nebubox start ./my-project --tool claude --github
+
+# Start with pnpm available in the container
+nebubox start ./my-project --tool claude --pnpm
 ```
 
 This will:
@@ -88,12 +92,12 @@ When you exit the shell, the container keeps running. Reconnect anytime with `ne
 
 | Command | Description |
 |---------|-------------|
-| `nebubox start <path> [--tool <name>] [--rebuild] [--github]` | Create/start container and attach shell |
+| `nebubox start <path> [--tool <name>] [--rebuild] [--github] [--pnpm]` | Create/start container and attach shell |
 | `nebubox list [--tool <name>]` | List managed containers |
 | `nebubox stop <name>` | Stop a running container |
 | `nebubox attach <name>` | Attach to a running container |
 | `nebubox remove <name>` | Remove a container |
-| `nebubox build [<tool>] [--tool <name>] [--rebuild] [--github]` | Build or rebuild a tool's Docker image |
+| `nebubox build [<tool>] [--tool <name>] [--rebuild] [--github] [--pnpm]` | Build or rebuild a tool's Docker image |
 
 ## Supported Tools
 
@@ -111,7 +115,7 @@ Each tool has a **profile** that defines its install method, auth directory, and
 - **Project** — `<your-project>` → `/home/coder/workspace`
 - **Auth** — `~/.nebubox/auth/<tool>/` → tool's config directory in the container
 
-Containers are named `nebubox-<tool>-<project-dir>` (or `nebubox-<tool>-<project-dir>-github` when `--github` is used) and labeled for easy filtering.
+Containers are named `nebubox-<tool>-<project-dir>` with optional suffixes (`-pnpm`, `-github`) when those flags are used, and labeled for easy filtering.
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/luixaviles/nebubox/main/docs/assets/nebubox-architecture.svg" alt="Nebubox Architecture" width="720" />
@@ -160,6 +164,9 @@ nebubox start ./my-project --tool claude --rebuild
 
 # Enable GitHub CLI for creating PRs, pushing, etc.
 nebubox start ./my-project --tool claude --github
+
+# Enable pnpm for projects that use it
+nebubox start ./my-project --tool claude --pnpm
 
 # Work on two projects with Claude Code
 nebubox start ~/projects/frontend --tool claude
@@ -228,6 +235,37 @@ git config --global user.email "you@example.com"
 ```
 
 These overrides persist across container restarts because `.gitconfig` lives in the mounted volume.
+
+### pnpm Support (`--pnpm`)
+
+The `--pnpm` flag installs [pnpm](https://pnpm.io/) in the container via Node.js [corepack](https://nodejs.org/api/corepack.html), so projects that use pnpm can run `pnpm install`, `pnpm run`, etc. without manual setup.
+
+**What it does:**
+
+- Builds a **separate image** tagged `nebubox-<tool>-pnpm:latest` (your regular image is untouched)
+- Runs `corepack enable pnpm` during the image build
+- npm remains available alongside pnpm — both coexist without conflict
+
+**Usage:**
+
+```bash
+nebubox start ./my-project --tool claude --pnpm
+```
+
+**Combined with `--github`:**
+
+```bash
+nebubox start ./my-project --tool claude --pnpm --github
+# Image: nebubox-claude-pnpm-github:latest
+```
+
+**Version pinning:** If your project has a `packageManager` field in `package.json` (e.g., `"packageManager": "pnpm@9.15.0"`), corepack will automatically use that version. Without it, the version bundled with the Node.js base image is used.
+
+**Pre-building the image:**
+
+```bash
+nebubox build claude --pnpm
+```
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebubox",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Run AI coding CLI tools safely inside Docker containers",
   "type": "module",
   "bin": {

--- a/scripts/e2e/test-pnpm.sh
+++ b/scripts/e2e/test-pnpm.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASS=0
+FAIL=0
+CLEANUP_IMAGES=()
+
+cleanup() {
+  for img in "${CLEANUP_IMAGES[@]}"; do
+    docker rmi -f "$img" >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT
+
+assert_ok() {
+  local desc="$1"
+  shift
+  set +e
+  "$@" >/dev/null 2>&1
+  local rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (exit $rc)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_output_contains() {
+  local desc="$1" pattern="$2"
+  shift 2
+  set +e
+  local output
+  output=$("$@" 2>&1)
+  set -e
+  if echo "$output" | grep -q "$pattern"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (pattern '$pattern' not found)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_output_not_contains() {
+  local desc="$1" pattern="$2"
+  shift 2
+  set +e
+  local output
+  output=$("$@" 2>&1)
+  set -e
+  if echo "$output" | grep -q "$pattern"; then
+    echo "  FAIL: $desc (pattern '$pattern' was found)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+echo "=== pnpm Support Tests ==="
+
+# Verify Docker is available
+if ! docker info >/dev/null 2>&1; then
+  echo "SKIP: Docker not available"
+  exit 0
+fi
+
+TOOL="claude"
+IMAGE_NAME="nebubox-${TOOL}-pnpm:latest"
+CLEANUP_IMAGES+=("$IMAGE_NAME")
+
+# ── Build with --pnpm ─────────────────────────────
+
+echo "  Building ${TOOL} image with --pnpm (this may take a while)..."
+assert_ok "build ${TOOL} --pnpm image via CLI" node dist/index.js build --tool "$TOOL" --pnpm
+
+# Verify image exists
+assert_ok "pnpm image exists after build" docker image inspect "$IMAGE_NAME"
+
+# ── Verify pnpm is installed ──────────────────────
+
+assert_ok "pnpm is installed" \
+  docker run --rm "$IMAGE_NAME" -c "pnpm --version"
+
+assert_output_contains "pnpm --version reports a version" "^[0-9]" \
+  docker run --rm "$IMAGE_NAME" -c "pnpm --version"
+
+assert_output_not_contains "pnpm runs without corepack download prompt" "Do you want to continue" \
+  docker run --rm "$IMAGE_NAME" -c "pnpm --version"
+
+# ── Verify npm still works alongside pnpm ─────────
+
+assert_ok "npm still available" \
+  docker run --rm "$IMAGE_NAME" -c "npm --version"
+
+# ── Combined: --pnpm --github ─────────────────────
+
+COMBINED_IMAGE="nebubox-${TOOL}-pnpm-github:latest"
+CLEANUP_IMAGES+=("$COMBINED_IMAGE")
+
+echo "  Building ${TOOL} image with --pnpm --github (this may take a while)..."
+assert_ok "build ${TOOL} --pnpm --github image" node dist/index.js build --tool "$TOOL" --pnpm --github
+
+assert_ok "combined image exists" docker image inspect "$COMBINED_IMAGE"
+
+assert_ok "pnpm works in combined image" \
+  docker run --rm "$COMBINED_IMAGE" -c "pnpm --version"
+
+assert_ok "gh works in combined image" \
+  docker run --rm "$COMBINED_IMAGE" -c "gh --version"
+
+echo ""
+echo "pnpm Support: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,10 +10,10 @@ import * as log from './utils/logger.js';
 import { promptToolSelection } from './utils/prompt.js';
 import { parseArgs } from './utils/parse-args.js';
 
-const VERSION = '0.2.1';
+const VERSION = '0.3.0';
 
 const KNOWN_FLAGS = new Set([
-  'tool', 'rebuild', 'github', 'help', 'h', 'version', 'v',
+  'tool', 'rebuild', 'github', 'pnpm', 'help', 'h', 'version', 'v',
 ]);
 
 function printHelp(): void {
@@ -26,18 +26,19 @@ USAGE
   nebubox <command> [options]
 
 COMMANDS
-  start <path> [--tool <name>] [--rebuild] [--github]   Create/start container and attach shell
+  start <path> [--tool <name>] [--rebuild] [--github] [--pnpm]   Create/start container and attach shell
   list [--tool <name>]           List managed containers
   stop <name>                    Stop a running container
   attach <name>                  Attach to a running container
   remove <name>                  Remove a container
-  build [<tool>] [--tool <name>] [--rebuild] [--github]   Build (or rebuild) a tool's Docker image
+  build [<tool>] [--tool <name>] [--rebuild] [--github] [--pnpm]   Build (or rebuild) a tool's Docker image
 
 OPTIONS
   --tool <name>    Tool to use (interactive prompt if omitted)
                    Available: ${tools}
   --rebuild        Rebuild image (no Docker cache) and recreate container
   --github         Install GitHub CLI and persist auth across sessions
+  --pnpm           Install pnpm package manager via corepack
   --help, -h       Show this help message
   --version, -v    Show version
 
@@ -95,7 +96,7 @@ export async function main(): Promise<void> {
           process.exit(1);
         }
         const startTool = flags['tool'] ?? await promptToolSelection();
-        await startCommand({ path, tool: startTool, rebuild: flags['rebuild'] === 'true', github: flags['github'] === 'true' });
+        await startCommand({ path, tool: startTool, rebuild: flags['rebuild'] === 'true', github: flags['github'] === 'true', pnpm: flags['pnpm'] === 'true' });
         break;
       }
 
@@ -139,7 +140,7 @@ export async function main(): Promise<void> {
 
       case 'build': {
         const buildTool = args[0] ?? flags['tool'] ?? await promptToolSelection();
-        await buildCommand({ tool: buildTool, rebuild: flags['rebuild'] === 'true', github: flags['github'] === 'true' });
+        await buildCommand({ tool: buildTool, rebuild: flags['rebuild'] === 'true', github: flags['github'] === 'true', pnpm: flags['pnpm'] === 'true' });
         break;
       }
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,5 +1,5 @@
 import { getToolProfile } from '../config/tools.js';
-import { buildImage, imageExists, getImageName } from '../docker/image.js';
+import { buildImage, imageExists, getImageName, type ImageOptions } from '../docker/image.js';
 import { ensureDocker, validateToolName } from '../utils/validation.js';
 import * as log from '../utils/logger.js';
 
@@ -7,6 +7,7 @@ export interface BuildOptions {
   tool: string;
   rebuild: boolean;
   github: boolean;
+  pnpm: boolean;
 }
 
 export async function buildCommand(opts: BuildOptions): Promise<void> {
@@ -15,10 +16,12 @@ export async function buildCommand(opts: BuildOptions): Promise<void> {
 
   const profile = getToolProfile(opts.tool)!;
 
-  const imageOpts = opts.github ? { github: true } : undefined;
+  const imageOpts: ImageOptions = {};
+  if (opts.github) imageOpts.github = true;
+  if (opts.pnpm) imageOpts.pnpm = true;
 
-  if (imageExists(profile.name, opts.github)) {
-    log.info(`Image ${getImageName(profile.name, opts.github)} already exists. Rebuilding...`);
+  if (imageExists(profile.name, imageOpts)) {
+    log.info(`Image ${getImageName(profile.name, imageOpts)} already exists. Rebuilding...`);
   }
 
   await buildImage(profile, opts.rebuild, imageOpts);

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -29,9 +29,10 @@ export function listCommand(opts: ListOptions): void {
     padRight('STATUS', 25) +
     padRight('TOOL', 12) +
     padRight('GITHUB', 10) +
+    padRight('PNPM', 8) +
     'PROJECT',
   );
-  console.log('-'.repeat(100));
+  console.log('-'.repeat(108));
 
   for (const c of containers) {
     console.log(
@@ -39,6 +40,7 @@ export function listCommand(opts: ListOptions): void {
       padRight(c.status, 25) +
       padRight(c.tool, 12) +
       padRight(c.github === 'true' ? 'yes' : 'no', 10) +
+      padRight(c.pnpm === 'true' ? 'yes' : 'no', 8) +
       c.project,
     );
   }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { getToolProfile } from '../config/tools.js';
-import { buildImage, imageExists } from '../docker/image.js';
+import { buildImage, imageExists, type ImageOptions } from '../docker/image.js';
 import {
   containerExists,
   isContainerRunning,
@@ -21,6 +21,7 @@ export interface StartOptions {
   tool: string;
   rebuild: boolean;
   github: boolean;
+  pnpm: boolean;
 }
 
 export async function startCommand(opts: StartOptions): Promise<void> {
@@ -29,12 +30,13 @@ export async function startCommand(opts: StartOptions): Promise<void> {
   ensureDocker();
 
   const profile = getToolProfile(opts.tool)!;
-  const containerName = getContainerName(profile.name, projectPath, opts.github);
-
-  const imageOpts = opts.github ? { github: true } : undefined;
+  const imageOpts: ImageOptions = {};
+  if (opts.github) imageOpts.github = true;
+  if (opts.pnpm) imageOpts.pnpm = true;
+  const containerName = getContainerName(profile.name, projectPath, { github: opts.github, pnpm: opts.pnpm });
 
   // Ensure image exists
-  if (!imageExists(profile.name, opts.github)) {
+  if (!imageExists(profile.name, imageOpts)) {
     log.info(`Image for ${profile.displayName} not found. Building...`);
     await buildImage(profile, opts.rebuild, imageOpts);
   } else if (opts.rebuild) {
@@ -64,7 +66,7 @@ export async function startCommand(opts: StartOptions): Promise<void> {
     }
   } else {
     log.step(`Creating container ${containerName}...`);
-    createContainer(profile, projectPath, opts.github ? { github: true } : undefined);
+    createContainer(profile, projectPath, imageOpts);
     startContainer(containerName);
     log.success(`Container ${containerName} created and started.`);
   }

--- a/src/config/constants.test.ts
+++ b/src/config/constants.test.ts
@@ -4,6 +4,8 @@ import {
   LABEL_TOOL,
   LABEL_PROJECT,
   LABEL_PROJECT_PATH,
+  LABEL_GITHUB,
+  LABEL_PNPM,
   IMAGE_PREFIX,
   CONTAINER_PREFIX,
   BASE_IMAGE,
@@ -21,6 +23,8 @@ describe('constants', () => {
     expect(LABEL_TOOL).toBe('nebubox.tool');
     expect(LABEL_PROJECT).toBe('nebubox.project');
     expect(LABEL_PROJECT_PATH).toBe('nebubox.project-path');
+    expect(LABEL_GITHUB).toBe('nebubox.github');
+    expect(LABEL_PNPM).toBe('nebubox.pnpm');
   });
 
   it('has correct prefixes', () => {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -3,6 +3,7 @@ export const LABEL_TOOL = 'nebubox.tool';
 export const LABEL_PROJECT = 'nebubox.project';
 export const LABEL_PROJECT_PATH = 'nebubox.project-path';
 export const LABEL_GITHUB = 'nebubox.github';
+export const LABEL_PNPM = 'nebubox.pnpm';
 
 export const IMAGE_PREFIX = 'nebubox-';
 export const CONTAINER_PREFIX = 'nebubox-';

--- a/src/docker/container.test.ts
+++ b/src/docker/container.test.ts
@@ -11,7 +11,7 @@ import {
   listContainers,
   getContainerImage,
 } from './container.js';
-import { CONTAINER_PREFIX, CODER_HOME, LABEL_MANAGED, LABEL_TOOL, LABEL_GITHUB } from '../config/constants.js';
+import { CONTAINER_PREFIX, CODER_HOME, LABEL_MANAGED, LABEL_TOOL, LABEL_GITHUB, LABEL_PNPM } from '../config/constants.js';
 import { ContainerError } from '../utils/errors.js';
 import type { ToolProfile } from '../config/tools.js';
 import { TOOL_PROFILES } from '../config/tools.js';
@@ -22,8 +22,10 @@ vi.mock('./client.js', () => ({
 }));
 
 vi.mock('./image.js', () => ({
-  getImageName: vi.fn((tool: string, github?: boolean) => {
-    const suffix = github ? '-github' : '';
+  getImageName: vi.fn((tool: string, options?: { github?: boolean; pnpm?: boolean }) => {
+    let suffix = '';
+    if (options?.pnpm) suffix += '-pnpm';
+    if (options?.github) suffix += '-github';
     return `nebubox-${tool}${suffix}:latest`;
   }),
 }));
@@ -61,15 +63,23 @@ describe('getContainerName', () => {
   });
 
   it('appends -github suffix when github is true', () => {
-    expect(getContainerName('claude', '/home/user/my-project', true)).toBe(`${CONTAINER_PREFIX}claude-my-project-github`);
+    expect(getContainerName('claude', '/home/user/my-project', { github: true })).toBe(`${CONTAINER_PREFIX}claude-my-project-github`);
   });
 
   it('does not append suffix when github is false', () => {
-    expect(getContainerName('claude', '/home/user/my-project', false)).toBe(`${CONTAINER_PREFIX}claude-my-project`);
+    expect(getContainerName('claude', '/home/user/my-project', { github: false })).toBe(`${CONTAINER_PREFIX}claude-my-project`);
   });
 
   it('does not append suffix when github is undefined', () => {
-    expect(getContainerName('claude', '/home/user/my-project', undefined)).toBe(`${CONTAINER_PREFIX}claude-my-project`);
+    expect(getContainerName('claude', '/home/user/my-project')).toBe(`${CONTAINER_PREFIX}claude-my-project`);
+  });
+
+  it('appends -pnpm suffix when pnpm is true', () => {
+    expect(getContainerName('claude', '/home/user/my-project', { pnpm: true })).toBe(`${CONTAINER_PREFIX}claude-my-project-pnpm`);
+  });
+
+  it('appends -pnpm-github suffix when both are true', () => {
+    expect(getContainerName('claude', '/home/user/my-project', { pnpm: true, github: true })).toBe(`${CONTAINER_PREFIX}claude-my-project-pnpm-github`);
   });
 });
 
@@ -77,7 +87,7 @@ describe('containerExists', () => {
   it('returns ContainerInfo when container is found', () => {
     vi.mocked(dockerExec).mockReturnValue({
       status: 0,
-      stdout: 'nebubox-claude-proj\tUp 2 hours\tclaude\tproj\t/home/user/proj\tfalse',
+      stdout: 'nebubox-claude-proj\tUp 2 hours\tclaude\tproj\t/home/user/proj\tfalse\tfalse',
       stderr: '',
     });
 
@@ -89,6 +99,7 @@ describe('containerExists', () => {
       project: 'proj',
       projectPath: '/home/user/proj',
       github: 'false',
+      pnpm: 'false',
     });
   });
 
@@ -113,6 +124,25 @@ describe('containerExists', () => {
     const args = vi.mocked(dockerExec).mock.calls[0][0];
     const format = args.find((a: string) => a.includes('nebubox.github'));
     expect(format).toBeDefined();
+  });
+
+  it('queries the nebubox.pnpm label', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: '', stderr: '' });
+    containerExists('test');
+    const args = vi.mocked(dockerExec).mock.calls[0][0];
+    const format = args.find((a: string) => a.includes('nebubox.pnpm'));
+    expect(format).toBeDefined();
+  });
+
+  it('returns pnpm false for old containers without pnpm label', () => {
+    vi.mocked(dockerExec).mockReturnValue({
+      status: 0,
+      stdout: 'nebubox-claude-proj\tUp 2 hours\tclaude\tproj\t/home/user/proj\tfalse\t',
+      stderr: '',
+    });
+    const info = containerExists('nebubox-claude-proj');
+    expect(info).not.toBeNull();
+    expect(info!.pnpm).toBe('false');
   });
 });
 
@@ -174,6 +204,20 @@ describe('createContainer', () => {
 
     const args = vi.mocked(dockerExec).mock.calls[0][0];
     expect(args).toContain(`${LABEL_GITHUB}=true`);
+  });
+
+  it('sets nebubox.pnpm label to false when pnpm is not enabled', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: 'abc', stderr: '' });
+    createContainer(mockProfile, '/home/user/proj');
+    const args = vi.mocked(dockerExec).mock.calls[0][0];
+    expect(args).toContain(`${LABEL_PNPM}=false`);
+  });
+
+  it('sets nebubox.pnpm label to true when pnpm is enabled', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: 'abc', stderr: '' });
+    createContainer(mockProfile, '/home/user/proj', { pnpm: true });
+    const args = vi.mocked(dockerExec).mock.calls[0][0];
+    expect(args).toContain(`${LABEL_PNPM}=true`);
   });
 });
 
@@ -257,6 +301,18 @@ describe('createContainer with github', () => {
     const lastArg = args[args.length - 1];
     expect(lastArg).toContain('-github:latest');
   });
+
+  it('uses pnpm-suffixed container name', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: 'abc', stderr: '' });
+    const name = createContainer(mockProfile, '/home/user/proj', { pnpm: true });
+    expect(name).toBe(`${CONTAINER_PREFIX}claude-proj-pnpm`);
+  });
+
+  it('uses pnpm-github-suffixed container name when both set', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: 'abc', stderr: '' });
+    const name = createContainer(mockProfile, '/home/user/proj', { pnpm: true, github: true });
+    expect(name).toBe(`${CONTAINER_PREFIX}claude-proj-pnpm-github`);
+  });
 });
 
 describe('startContainer', () => {
@@ -311,7 +367,7 @@ describe('listContainers', () => {
   it('returns parsed container list', () => {
     vi.mocked(dockerExec).mockReturnValue({
       status: 0,
-      stdout: 'c1\tUp\tclaude\tproj1\t/p1\tfalse\nc2\tExited\tgemini\tproj2\t/p2\ttrue',
+      stdout: 'c1\tUp\tclaude\tproj1\t/p1\tfalse\tfalse\nc2\tExited\tgemini\tproj2\t/p2\ttrue\tfalse',
       stderr: '',
     });
 
@@ -324,6 +380,7 @@ describe('listContainers', () => {
       project: 'proj1',
       projectPath: '/p1',
       github: 'false',
+      pnpm: 'false',
     });
     expect(list[1]).toEqual({
       name: 'c2',
@@ -332,6 +389,7 @@ describe('listContainers', () => {
       project: 'proj2',
       projectPath: '/p2',
       github: 'true',
+      pnpm: 'false',
     });
   });
 
@@ -368,6 +426,14 @@ describe('listContainers', () => {
 
     const args = vi.mocked(dockerExec).mock.calls[0][0];
     const format = args.find((a: string) => a.includes('nebubox.github'));
+    expect(format).toBeDefined();
+  });
+
+  it('queries the nebubox.pnpm label', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: '', stderr: '' });
+    listContainers();
+    const args = vi.mocked(dockerExec).mock.calls[0][0];
+    const format = args.find((a: string) => a.includes('nebubox.pnpm'));
     expect(format).toBeDefined();
   });
 });

--- a/src/docker/container.ts
+++ b/src/docker/container.ts
@@ -8,6 +8,7 @@ import {
   LABEL_PROJECT,
   LABEL_PROJECT_PATH,
   LABEL_GITHUB,
+  LABEL_PNPM,
   CODER_HOME,
   WORKSPACE_DIR,
 } from '../config/constants.js';
@@ -18,6 +19,7 @@ import { ContainerError } from '../utils/errors.js';
 
 export interface ContainerOptions {
   github?: boolean;
+  pnpm?: boolean;
 }
 
 export interface ContainerInfo {
@@ -27,11 +29,15 @@ export interface ContainerInfo {
   project: string;
   projectPath: string;
   github: string;
+  pnpm: string;
 }
 
-export function getContainerName(toolName: string, projectPath: string, github?: boolean): string {
+// Suffixes appended in fixed order: -pnpm before -github
+export function getContainerName(toolName: string, projectPath: string, options?: ContainerOptions): string {
   const projectBasename = basename(projectPath);
-  const suffix = github ? '-github' : '';
+  let suffix = '';
+  if (options?.pnpm) suffix += '-pnpm';
+  if (options?.github) suffix += '-github';
   return `${CONTAINER_PREFIX}${toolName}-${projectBasename}${suffix}`;
 }
 
@@ -39,7 +45,7 @@ export function containerExists(name: string): ContainerInfo | null {
   const result = dockerExec([
     'ps', '-a',
     '--filter', `name=^/${name}$`,
-    '--format', '{{.Names}}\t{{.Status}}\t{{.Label "nebubox.tool"}}\t{{.Label "nebubox.project"}}\t{{.Label "nebubox.project-path"}}\t{{.Label "nebubox.github"}}',
+    '--format', '{{.Names}}\t{{.Status}}\t{{.Label "nebubox.tool"}}\t{{.Label "nebubox.project"}}\t{{.Label "nebubox.project-path"}}\t{{.Label "nebubox.github"}}\t{{.Label "nebubox.pnpm"}}',
   ]);
 
   if (result.status !== 0 || !result.stdout) {
@@ -47,7 +53,7 @@ export function containerExists(name: string): ContainerInfo | null {
   }
 
   const parts = result.stdout.split('\t');
-  if (parts.length < 6) return null;
+  if (parts.length < 7) return null;
 
   return {
     name: parts[0],
@@ -56,6 +62,7 @@ export function containerExists(name: string): ContainerInfo | null {
     project: parts[3],
     projectPath: parts[4],
     github: parts[5],
+    pnpm: parts[6] || 'false',
   };
 }
 
@@ -75,8 +82,9 @@ export function createContainer(
   options?: ContainerOptions,
 ): string {
   const github = options?.github ?? false;
-  const name = getContainerName(profile.name, projectPath, github);
-  const imageName = getImageName(profile.name, github);
+  const pnpm = options?.pnpm ?? false;
+  const name = getContainerName(profile.name, projectPath, { github, pnpm });
+  const imageName = getImageName(profile.name, { github, pnpm });
   const hostAuthDir = ensureAuthDir(profile.name);
   const containerAuthDir = `${CODER_HOME}/${profile.authDir}`;
   const projectBasename = basename(projectPath);
@@ -89,6 +97,7 @@ export function createContainer(
     '--label', `${LABEL_PROJECT}=${projectBasename}`,
     '--label', `${LABEL_PROJECT_PATH}=${projectPath}`,
     '--label', `${LABEL_GITHUB}=${github}`,
+    '--label', `${LABEL_PNPM}=${pnpm}`,
     '-it',
     '-v', `${projectPath}:${WORKSPACE_DIR}`,
     '-v', `${hostAuthDir}:${containerAuthDir}`,
@@ -162,7 +171,7 @@ export function listContainers(toolFilter?: string): ContainerInfo[] {
 
   args.push(
     '--format',
-    '{{.Names}}\t{{.Status}}\t{{.Label "nebubox.tool"}}\t{{.Label "nebubox.project"}}\t{{.Label "nebubox.project-path"}}\t{{.Label "nebubox.github"}}',
+    '{{.Names}}\t{{.Status}}\t{{.Label "nebubox.tool"}}\t{{.Label "nebubox.project"}}\t{{.Label "nebubox.project-path"}}\t{{.Label "nebubox.github"}}\t{{.Label "nebubox.pnpm"}}',
   );
 
   const result = dockerExec(args);
@@ -180,6 +189,7 @@ export function listContainers(toolFilter?: string): ContainerInfo[] {
       project: parts[3],
       projectPath: parts[4],
       github: parts[5],
+      pnpm: parts[6] || 'false',
     };
   });
 }

--- a/src/docker/image.test.ts
+++ b/src/docker/image.test.ts
@@ -29,11 +29,23 @@ describe('getImageName', () => {
   });
 
   it('appends -github suffix when github is true', () => {
-    expect(getImageName('claude', true)).toBe(`${IMAGE_PREFIX}claude-github:latest`);
+    expect(getImageName('claude', { github: true })).toBe(`${IMAGE_PREFIX}claude-github:latest`);
   });
 
   it('does not append suffix when github is false', () => {
-    expect(getImageName('claude', false)).toBe(`${IMAGE_PREFIX}claude:latest`);
+    expect(getImageName('claude', { github: false })).toBe(`${IMAGE_PREFIX}claude:latest`);
+  });
+
+  it('appends -pnpm suffix when pnpm is true', () => {
+    expect(getImageName('claude', { pnpm: true })).toBe(`${IMAGE_PREFIX}claude-pnpm:latest`);
+  });
+
+  it('appends -pnpm-github suffix when both are true', () => {
+    expect(getImageName('claude', { pnpm: true, github: true })).toBe(`${IMAGE_PREFIX}claude-pnpm-github:latest`);
+  });
+
+  it('returns no suffix when options is empty object', () => {
+    expect(getImageName('claude', {})).toBe(`${IMAGE_PREFIX}claude:latest`);
   });
 });
 
@@ -140,6 +152,58 @@ describe('generateDockerfile with github', () => {
     expect(df).not.toContain('githubcli-archive-keyring.gpg');
     expect(df).not.toContain('COPY nebubox-gh-setup');
     expect(df).not.toContain('GIT_CONFIG_GLOBAL');
+  });
+});
+
+describe('generateDockerfile with pnpm', () => {
+  it('includes corepack enable and prepare when pnpm is true', () => {
+    const df = generateDockerfile(mockProfile, { pnpm: true });
+    expect(df).toContain('RUN corepack enable pnpm');
+    expect(df).toContain('RUN corepack prepare pnpm@latest --activate');
+  });
+
+  it('does not include corepack when pnpm is not set', () => {
+    const df = generateDockerfile(mockProfile);
+    expect(df).not.toContain('corepack enable pnpm');
+    expect(df).not.toContain('corepack prepare');
+  });
+
+  it('corepack enable runs as root before USER coder', () => {
+    const df = generateDockerfile(mockProfile, { pnpm: true });
+    const enableIndex = df.indexOf('corepack enable pnpm');
+    const userIndex = df.indexOf(`USER ${CODER_USER}`);
+    expect(enableIndex).toBeGreaterThan(-1);
+    expect(enableIndex).toBeLessThan(userIndex);
+  });
+
+  it('corepack prepare runs as coder after USER coder', () => {
+    const df = generateDockerfile(mockProfile, { pnpm: true });
+    const userIndex = df.indexOf(`USER ${CODER_USER}`);
+    const prepareIndex = df.indexOf('corepack prepare pnpm@latest --activate');
+    expect(prepareIndex).toBeGreaterThan(-1);
+    expect(prepareIndex).toBeGreaterThan(userIndex);
+  });
+
+  it('corepack enable appears after apt-get install', () => {
+    const df = generateDockerfile(mockProfile, { pnpm: true });
+    const aptIndex = df.indexOf('apt-get install');
+    const enableIndex = df.indexOf('corepack enable pnpm');
+    expect(enableIndex).toBeGreaterThan(aptIndex);
+  });
+
+  it('includes both pnpm and github blocks when both are true', () => {
+    const df = generateDockerfile(mockProfile, { pnpm: true, github: true });
+    expect(df).toContain('RUN corepack enable pnpm');
+    expect(df).toContain('RUN corepack prepare pnpm@latest --activate');
+    expect(df).toContain('apt-get install -y --no-install-recommends gh');
+    // enable runs as root (before USER coder), prepare runs as coder (after)
+    const enableIndex = df.indexOf('corepack enable pnpm');
+    const ghIndex = df.indexOf('apt-get install -y --no-install-recommends gh');
+    const userIndex = df.indexOf(`USER ${CODER_USER}`);
+    const prepareIndex = df.indexOf('corepack prepare pnpm@latest --activate');
+    expect(enableIndex).toBeLessThan(userIndex);
+    expect(ghIndex).toBeLessThan(userIndex);
+    expect(prepareIndex).toBeGreaterThan(userIndex);
   });
 });
 

--- a/src/docker/image.ts
+++ b/src/docker/image.ts
@@ -19,16 +19,21 @@ import { GH_SETUP_SCRIPT, GH_BASHRC_HOOK } from '../github/setup-script.js';
 
 export interface ImageOptions {
   github?: boolean;
+  pnpm?: boolean;
 }
 
-export function getImageName(toolName: string, github?: boolean): string {
-  const suffix = github ? '-github' : '';
+// Suffixes appended in fixed order: -pnpm before -github
+export function getImageName(toolName: string, options?: ImageOptions): string {
+  let suffix = '';
+  if (options?.pnpm) suffix += '-pnpm';
+  if (options?.github) suffix += '-github';
   return `${IMAGE_PREFIX}${toolName}${suffix}:latest`;
 }
 
 export function generateDockerfile(profile: ToolProfile, options?: ImageOptions): string {
   const lines: string[] = [];
   const github = options?.github ?? false;
+  const pnpm = options?.pnpm ?? false;
 
   lines.push(`FROM ${BASE_IMAGE}`);
   lines.push('');
@@ -54,6 +59,12 @@ export function generateDockerfile(profile: ToolProfile, options?: ImageOptions)
     lines.push('COPY nebubox-gh-setup /usr/local/bin/nebubox-gh-setup');
     lines.push('RUN chmod +x /usr/local/bin/nebubox-gh-setup');
     lines.push('COPY nebubox-bashrc-hook /tmp/nebubox-bashrc-hook');
+    lines.push('');
+  }
+
+  // pnpm: enable shim as root (writes symlinks to /usr/local/bin/)
+  if (pnpm) {
+    lines.push('RUN corepack enable pnpm');
     lines.push('');
   }
 
@@ -84,6 +95,12 @@ export function generateDockerfile(profile: ToolProfile, options?: ImageOptions)
   lines.push(`ARG NPM_CONFIG_PREFIX="${CODER_HOME}/.npm-global"`);
   lines.push(`ENV PATH="${CODER_HOME}/.npm-global/bin:$PATH"`);
   lines.push('');
+
+  // pnpm: download and cache as coder user (cache lands in ~/.cache/node/corepack/)
+  if (pnpm) {
+    lines.push('RUN corepack prepare pnpm@latest --activate');
+    lines.push('');
+  }
 
   // Tool-specific install
   for (const cmd of profile.installCommands) {
@@ -116,15 +133,14 @@ export function generateDockerfile(profile: ToolProfile, options?: ImageOptions)
   return lines.join('\n');
 }
 
-export function imageExists(toolName: string, github?: boolean): boolean {
-  const imageName = getImageName(toolName, github);
+export function imageExists(toolName: string, options?: ImageOptions): boolean {
+  const imageName = getImageName(toolName, options);
   const result = dockerExec(['image', 'inspect', imageName]);
   return result.status === 0;
 }
 
 export async function buildImage(profile: ToolProfile, noCache = false, options?: ImageOptions): Promise<void> {
-  const github = options?.github ?? false;
-  const imageName = getImageName(profile.name, github);
+  const imageName = getImageName(profile.name, options);
   const dockerfile = generateDockerfile(profile, options);
 
   const tmpDir = mkdtempSync(join(tmpdir(), 'nebubox-'));
@@ -134,7 +150,7 @@ export async function buildImage(profile: ToolProfile, noCache = false, options?
     writeFileSync(dockerfilePath, dockerfile);
 
     // Write gh files into the build context so COPY can find them
-    if (github) {
+    if (options?.github) {
       writeFileSync(join(tmpDir, 'nebubox-gh-setup'), GH_SETUP_SCRIPT);
       writeFileSync(join(tmpDir, 'nebubox-bashrc-hook'), GH_BASHRC_HOOK);
     }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -52,6 +52,12 @@ describe('unknown flag warnings', () => {
     expect(log.warn).not.toHaveBeenCalledWith(expect.stringContaining('Unknown flag'));
   });
 
+  it('does not warn about --pnpm', async () => {
+    process.argv = ['node', 'nebubox', '--help', '--pnpm'];
+    await main();
+    expect(log.warn).not.toHaveBeenCalledWith(expect.stringContaining('Unknown flag'));
+  });
+
   it('warns about --no-cache (replaced by --rebuild)', async () => {
     process.argv = ['node', 'nebubox', 'build', '--tool', 'claude', '--no-cache'];
     await main();


### PR DESCRIPTION
## Summary

- Adds `--pnpm` flag to `start` and `build` commands, installing pnpm via corepack alongside npm (additive, not a replacement)
- Splits corepack setup: `corepack enable pnpm` runs as root (symlinks in `/usr/local/bin/`), `corepack prepare pnpm@latest --activate` runs as `coder` user (cache in `~/.cache/node/corepack/`)
- Refactors image/container name helpers from positional booleans to `{ github?, pnpm? }` options objects for cleaner flag composition
- Adds PNPM column to `list` output, `nebubox.pnpm` Docker label, and backwards-compatible fallback for old containers
- Bumps version to 0.3.0

## Changes

- **`src/docker/image.ts`** — `ImageOptions` interface, corepack split, suffix ordering (`-pnpm` before `-github`)
- **`src/docker/container.ts`** — `ContainerOptions`, pnpm label, 7-field format string with fallback
- **`src/commands/start.ts`** / **`src/commands/build.ts`** — thread `pnpm` option through
- **`src/commands/list.ts`** — PNPM column in table output
- **`src/cli.ts`** — `--pnpm` flag, updated help text, version 0.3.0
- **`README.md`** — pnpm documentation and examples
- **Tests** — unit tests for all layers + new e2e test (`scripts/e2e/test-pnpm.sh`)

## Test plan

- [x] All 165 unit tests pass (`npm test`)
- [x] TypeScript compiles cleanly (`npm run build`)
- [x] Run `scripts/e2e/test-pnpm.sh` to verify pnpm works in built containers
- [x] Manual: `nebubox start ./project --pnpm` → `pnpm --version` shows version without corepack download prompt
- [x] Manual: `nebubox start ./project --pnpm --github` → both pnpm and gh work
- [x] Manual: `nebubox list` shows PNPM column