### PR TITLE
feat: add Antigravity CLI support, deprecate Gemini CLI, and bump version to 0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ npm-debug.log*
 
 # Logs
 *.log
+
+.antigravitycli/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Running AI coding tools with full permissions is powerful but risky: a single ba
 
 ## Features
 
-- **Multi-tool support** — Claude Code, Gemini CLI, and Codex CLI out of the box
+- **Multi-tool support** — Claude Code, Antigravity CLI, Codex CLI, and Gemini CLI out of the box
 - **Filesystem isolation** — only the mounted project directory is accessible
 - **Auth persistence** — credentials survive across container restarts via shared host directories
 - **Zero runtime dependencies** — just Node.js and Docker
@@ -70,8 +70,9 @@ nebubox start ./my-project
 
 # Start with a specific tool
 nebubox start ./my-project --tool claude
-nebubox start ./my-project --tool gemini
+nebubox start ./my-project --tool antigravity
 nebubox start ./my-project --tool codex
+nebubox start ./my-project --tool gemini
 
 # Start with GitHub CLI support
 nebubox start ./my-project --tool claude --github
@@ -104,8 +105,9 @@ When you exit the shell, the container keeps running. Reconnect anytime with `ne
 | Tool | Launch command inside container |
 |------|-------------------------------|
 | `claude` | `claude --dangerously-skip-permissions` |
-| `gemini` | `gemini --approval-mode=yolo --sandbox=false` |
+| `antigravity` | `agy --dangerously-skip-permissions` |
 | `codex` | `codex --dangerously-bypass-approvals-and-sandbox` |
+| `gemini` (Deprecated) | `gemini --approval-mode=yolo --sandbox=false` |
 
 When `--tool` is omitted, nebubox presents an interactive prompt to select a tool.
 
@@ -130,8 +132,9 @@ Containers are named `nebubox-<tool>-<project-dir>` with optional suffixes (`-pn
 ~/.nebubox/
   auth/
     claude/         # Claude Code credentials & config (~/.claude)
-    gemini/         # Gemini CLI credentials
+    antigravity/    # Antigravity CLI credentials
     codex/          # Codex CLI credentials
+    gemini/         # Gemini CLI credentials
     github/         # GitHub CLI auth + .gitconfig (when --github is used)
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ description: Run AI coding CLI tools like Claude Code, Gemini CLI, and Codex saf
 
 ## Key Features
 
-- **Multi-tool support** — Claude Code, Gemini CLI, and Codex CLI out of the box
+- **Multi-tool support** — Claude Code, Antigravity CLI, Codex CLI, and Gemini CLI out of the box
 - **Filesystem isolation** — only the mounted project directory is accessible
 - **Auth persistence** — credentials survive across container restarts via shared host directories
 - **Zero runtime dependencies** — just Node.js and Docker
@@ -23,8 +23,9 @@ description: Run AI coding CLI tools like Claude Code, Gemini CLI, and Codex saf
 | Tool | Launch command inside container |
 |------|-------------------------------|
 | Claude Code | `claude --dangerously-skip-permissions` |
-| Gemini CLI | `gemini --approval-mode=yolo --sandbox=false` |
+| Antigravity CLI | `agy --dangerously-skip-permissions` |
 | Codex CLI | `codex --dangerously-bypass-approvals-and-sandbox` |
+| Gemini CLI (Deprecated) | `gemini --approval-mode=yolo --sandbox=false` |
 
 When `--tool` is omitted, Nebubox presents an interactive prompt to select a tool.
 
@@ -36,8 +37,9 @@ nebubox start ./my-project
 
 # Start with a specific tool
 nebubox start ./my-project --tool claude
-nebubox start ./my-project --tool gemini
+nebubox start ./my-project --tool antigravity
 nebubox start ./my-project --tool codex
+nebubox start ./my-project --tool gemini
 
 # Start with GitHub CLI support
 nebubox start ./my-project --tool claude --github
@@ -66,8 +68,9 @@ Containers are named `nebubox-<tool>-<project-dir>` (or `nebubox-<tool>-<project
 ~/.nebubox/
   auth/
     claude/         # Claude Code credentials & config
-    gemini/         # Gemini CLI credentials
+    antigravity/    # Antigravity CLI credentials
     codex/          # Codex CLI credentials
+    gemini/         # Gemini CLI credentials
     github/         # GitHub CLI auth + .gitconfig (when --github is used)
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebubox",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Run AI coding CLI tools safely inside Docker containers",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import * as log from './utils/logger.js';
 import { promptToolSelection } from './utils/prompt.js';
 import { parseArgs } from './utils/parse-args.js';
 
-const VERSION = '0.3.0';
+const VERSION = '0.4.0';
 
 const KNOWN_FLAGS = new Set([
   'tool', 'rebuild', 'github', 'pnpm', 'help', 'h', 'version', 'v',

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -72,6 +72,9 @@ export async function startCommand(opts: StartOptions): Promise<void> {
   }
 
   log.hint(profile.hint);
+  if (profile.warning) {
+    log.warn(profile.warning);
+  }
 
   if (opts.github) {
     const hostsFile = join(getAuthDir('github'), 'hosts.yml');

--- a/src/config/tools.test.ts
+++ b/src/config/tools.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { TOOL_PROFILES, getToolProfile, getToolNames, type ToolProfile } from './tools.js';
 
 describe('TOOL_PROFILES', () => {
-  it('contains claude, gemini, and codex', () => {
-    expect(Object.keys(TOOL_PROFILES)).toEqual(['claude', 'gemini', 'codex']);
+  it('contains claude, antigravity, codex, and gemini', () => {
+    expect(Object.keys(TOOL_PROFILES)).toEqual(['claude', 'antigravity', 'codex', 'gemini']);
   });
 
   it.each(Object.entries(TOOL_PROFILES))('%s has required fields', (_name, profile: ToolProfile) => {
@@ -37,7 +37,7 @@ describe('getToolProfile', () => {
 describe('getToolNames', () => {
   it('returns array of tool names', () => {
     const names = getToolNames();
-    expect(names).toEqual(['claude', 'gemini', 'codex']);
+    expect(names).toEqual(['claude', 'antigravity', 'codex', 'gemini']);
   });
 
   it('returns a new array each time', () => {

--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -7,6 +7,7 @@ export interface ToolProfile {
   authDir: string;
   authFiles: string[];
   hint: string;
+  warning?: string;
 }
 
 const claude: ToolProfile = {
@@ -30,7 +31,7 @@ const claude: ToolProfile = {
 
 const gemini: ToolProfile = {
   name: 'gemini',
-  displayName: 'Gemini CLI',
+  displayName: 'Gemini CLI (Deprecated)',
   packages: [],
   installCommands: [
     'npm install -g @google/gemini-cli',
@@ -39,6 +40,7 @@ const gemini: ToolProfile = {
   authDir: '.gemini',
   authFiles: [],
   hint: 'Run `gemini --approval-mode=yolo --sandbox=false` to start Gemini CLI.',
+  warning: 'Gemini CLI is deprecated and will transition to Antigravity CLI. See https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/',
 };
 
 const codex: ToolProfile = {
@@ -54,10 +56,26 @@ const codex: ToolProfile = {
   hint: 'Run `codex --dangerously-bypass-approvals-and-sandbox` to start Codex CLI.',
 };
 
+const antigravity: ToolProfile = {
+  name: 'antigravity',
+  displayName: 'Antigravity CLI',
+  packages: [],
+  installCommands: [
+    'curl -fsSL https://antigravity.google/cli/install.sh | bash',
+  ],
+  envVars: {
+    PATH: '/home/coder/.local/bin:$PATH',
+  },
+  authDir: '.config/antigravity',
+  authFiles: [],
+  hint: 'Run `agy --dangerously-skip-permissions` to start Antigravity CLI.',
+};
+
 export const TOOL_PROFILES: Record<string, ToolProfile> = {
   claude,
-  gemini,
+  antigravity,
   codex,
+  gemini,
 };
 
 export function getToolProfile(name: string): ToolProfile | undefined {

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -35,6 +35,7 @@ describe('validateToolName', () => {
     expect(() => validateToolName('claude')).not.toThrow();
     expect(() => validateToolName('gemini')).not.toThrow();
     expect(() => validateToolName('codex')).not.toThrow();
+    expect(() => validateToolName('antigravity')).not.toThrow();
   });
 
   it('throws ValidationError for unknown tool', () => {
@@ -49,6 +50,7 @@ describe('validateToolName', () => {
       expect((e as Error).message).toContain('claude');
       expect((e as Error).message).toContain('gemini');
       expect((e as Error).message).toContain('codex');
+      expect((e as Error).message).toContain('antigravity');
     }
   });
 });


### PR DESCRIPTION
This PR introduces the following changes:
- Adds support for the new Antigravity CLI.
- Deprecates the existing Gemini CLI.
- Bumps the version to 0.4.0.