### PR TITLE
test: achieve 100% test coverage for cli.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nebubox",
-  "version": "0.1.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nebubox",
-      "version": "0.1.1",
+      "version": "0.4.0",
       "license": "MIT",
       "bin": {
         "nebubox": "dist/index.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,12 +69,12 @@ export async function main(): Promise<void> {
 
   const { command, args, flags } = parseArgs(process.argv);
 
-  if (flags['help'] || flags['h'] || command === 'help') {
+  if (flags['help'] || flags['h'] || command === 'help' || command === '-h') {
     printHelp();
     return;
   }
 
-  if (flags['version'] || flags['v'] || command === 'version') {
+  if (flags['version'] || flags['v'] || command === 'version' || command === '-v') {
     console.log(`nebubox v${VERSION}`);
     return;
   }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -72,3 +72,196 @@ describe('unknown flag warnings', () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('--recreate'));
   });
 });
+
+describe('main CLI functionality', () => {
+  let savedArgv: string[];
+
+  beforeEach(() => {
+    savedArgv = process.argv;
+    vi.spyOn(log, 'error').mockImplementation(() => {});
+    vi.spyOn(log, 'info').mockImplementation(() => {});
+    vi.spyOn(log, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation((code?: number | string | null | undefined) => {
+      throw new Error(`process.exit(${code})`);
+    });
+  });
+
+  afterEach(() => {
+    process.argv = savedArgv;
+    vi.restoreAllMocks();
+  });
+
+  it('prints help when --help, -h, or command help is provided', async () => {
+    process.argv = ['node', 'nebubox', '--help'];
+    await main();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Run AI coding CLI tools safely inside Docker containers'));
+
+    process.argv = ['node', 'nebubox', '-h'];
+    await main();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Run AI coding CLI tools safely inside Docker containers'));
+
+    process.argv = ['node', 'nebubox', 'help'];
+    await main();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Run AI coding CLI tools safely inside Docker containers'));
+  });
+
+  it('prints version when --version, -v, or command version is provided', async () => {
+    process.argv = ['node', 'nebubox', '--version'];
+    await main();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('nebubox v'));
+
+    process.argv = ['node', 'nebubox', '-v'];
+    await main();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('nebubox v'));
+
+    process.argv = ['node', 'nebubox', 'version'];
+    await main();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('nebubox v'));
+  });
+
+  it('prints help and exits with 1 when no command is provided', async () => {
+    process.argv = ['node', 'nebubox'];
+    await expect(main()).rejects.toThrow('process.exit(1)');
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Run AI coding CLI tools safely inside Docker containers'));
+  });
+
+  it('fails to start when path is missing', async () => {
+    process.argv = ['node', 'nebubox', 'start'];
+    await expect(main()).rejects.toThrow('process.exit(1)');
+    expect(log.error).toHaveBeenCalledWith('Missing required argument: <path>');
+  });
+
+  it('starts command with path and flags', async () => {
+    const { startCommand } = await import('./commands/start.js');
+    process.argv = ['node', 'nebubox', 'start', './my-path', '--tool', 'claude', '--rebuild', 'true', '--github', 'true', '--pnpm', 'true'];
+    await main();
+    expect(startCommand).toHaveBeenCalledWith({
+      path: './my-path',
+      tool: 'claude',
+      rebuild: true,
+      github: true,
+      pnpm: true,
+    });
+  });
+
+  it('starts command and prompts for tool if tool flag is missing', async () => {
+    const { startCommand } = await import('./commands/start.js');
+    const { promptToolSelection } = await import('./utils/prompt.js');
+    vi.mocked(promptToolSelection).mockResolvedValue('claude');
+    process.argv = ['node', 'nebubox', 'start', './my-path'];
+    await main();
+    expect(promptToolSelection).toHaveBeenCalled();
+    expect(startCommand).toHaveBeenCalledWith({
+      path: './my-path',
+      tool: 'claude',
+      rebuild: false,
+      github: false,
+      pnpm: false,
+    });
+  });
+
+  it('lists containers', async () => {
+    const { listCommand } = await import('./commands/list.js');
+    process.argv = ['node', 'nebubox', 'list', '--tool', 'claude'];
+    await main();
+    expect(listCommand).toHaveBeenCalledWith({ tool: 'claude' });
+  });
+
+  it('fails to stop when name is missing', async () => {
+    process.argv = ['node', 'nebubox', 'stop'];
+    await expect(main()).rejects.toThrow('process.exit(1)');
+    expect(log.error).toHaveBeenCalledWith('Missing required argument: <name>');
+  });
+
+  it('stops command when name is provided', async () => {
+    const { stopCommand } = await import('./commands/stop.js');
+    process.argv = ['node', 'nebubox', 'stop', 'my-container'];
+    await main();
+    expect(stopCommand).toHaveBeenCalledWith('my-container');
+  });
+
+  it('fails to attach when name is missing', async () => {
+    process.argv = ['node', 'nebubox', 'attach'];
+    await expect(main()).rejects.toThrow('process.exit(1)');
+    expect(log.error).toHaveBeenCalledWith('Missing required argument: <name>');
+  });
+
+  it('attaches command when name is provided', async () => {
+    const { attachCommand } = await import('./commands/attach.js');
+    process.argv = ['node', 'nebubox', 'attach', 'my-container'];
+    await main();
+    expect(attachCommand).toHaveBeenCalledWith('my-container');
+  });
+
+  it('fails to remove when name is missing', async () => {
+    process.argv = ['node', 'nebubox', 'remove'];
+    await expect(main()).rejects.toThrow('process.exit(1)');
+    expect(log.error).toHaveBeenCalledWith('Missing required argument: <name>');
+  });
+
+  it('removes command when name is provided', async () => {
+    const { removeCommand } = await import('./commands/remove.js');
+    process.argv = ['node', 'nebubox', 'remove', 'my-container'];
+    await main();
+    expect(removeCommand).toHaveBeenCalledWith('my-container');
+  });
+
+  it('builds command with tool and flags', async () => {
+    const { buildCommand } = await import('./commands/build.js');
+    process.argv = ['node', 'nebubox', 'build', 'claude', '--rebuild', 'true', '--github', 'true', '--pnpm', 'true'];
+    await main();
+    expect(buildCommand).toHaveBeenCalledWith({
+      tool: 'claude',
+      rebuild: true,
+      github: true,
+      pnpm: true,
+    });
+  });
+
+  it('builds command and prompts for tool if missing', async () => {
+    const { buildCommand } = await import('./commands/build.js');
+    const { promptToolSelection } = await import('./utils/prompt.js');
+    vi.mocked(promptToolSelection).mockResolvedValue('claude');
+    process.argv = ['node', 'nebubox', 'build'];
+    await main();
+    expect(promptToolSelection).toHaveBeenCalled();
+    expect(buildCommand).toHaveBeenCalledWith({
+      tool: 'claude',
+      rebuild: false,
+      github: false,
+      pnpm: false,
+    });
+  });
+
+  it('fails on unknown command', async () => {
+    process.argv = ['node', 'nebubox', 'unknown-cmd'];
+    await expect(main()).rejects.toThrow('process.exit(1)');
+    expect(log.error).toHaveBeenCalledWith('Unknown command: unknown-cmd');
+  });
+
+  it('exits with error message when NebuboxError is thrown', async () => {
+    const { startCommand } = await import('./commands/start.js');
+    const { NebuboxError } = await import('./utils/errors.js');
+    vi.mocked(startCommand).mockRejectedValue(new NebuboxError('Some Nebubox error'));
+    process.argv = ['node', 'nebubox', 'start', './my-path', '--tool', 'claude'];
+    await expect(main()).rejects.toThrow('process.exit(1)');
+    expect(log.error).toHaveBeenCalledWith('Some Nebubox error');
+  });
+
+  it('exits with error message when generic Error is thrown', async () => {
+    const { startCommand } = await import('./commands/start.js');
+    vi.mocked(startCommand).mockRejectedValue(new Error('Some generic error'));
+    process.argv = ['node', 'nebubox', 'start', './my-path', '--tool', 'claude'];
+    await expect(main()).rejects.toThrow('process.exit(1)');
+    expect(log.error).toHaveBeenCalledWith('Some generic error');
+  });
+
+  it('throws unexpected non-error objects', async () => {
+    const { startCommand } = await import('./commands/start.js');
+    vi.mocked(startCommand).mockRejectedValue('unexpected string error');
+    process.argv = ['node', 'nebubox', 'start', './my-path', '--tool', 'claude'];
+    await expect(main()).rejects.toThrow('unexpected string error');
+  });
+});
+


### PR DESCRIPTION
This PR introduces comprehensive unit tests for `src/cli.ts`, bringing its test coverage from 35.38% to 100%.

### Changes
- Mocked all command files and utility imports to test the CLI entrypoint isolation.
- Handled error paths, unknown flags/commands, version flags, and help printouts.
- Fixed a minor bug in `src/cli.ts` where `-h` and `-v` flags were treated as unknown commands due to being parsed as positional arguments.