### PR TITLE
fix(antigravity): persist and share auth credentials across projects

### DIFF
--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -66,7 +66,7 @@ const antigravity: ToolProfile = {
   envVars: {
     PATH: '/home/coder/.local/bin:$PATH',
   },
-  authDir: '.config/antigravity',
+  authDir: '.gemini/antigravity-cli',
   authFiles: [],
   hint: 'Run `agy --dangerously-skip-permissions` to start Antigravity CLI.',
 };


### PR DESCRIPTION
### Summary
This PR fixes the issue where the Antigravity CLI asks for authentication again when switching across different project containers.

### Changes
* Updated `authDir` in the `antigravity` tool profile from `.config/antigravity` to `.gemini/antigravity-cli`.