### PR TITLE
feat: add Playwright support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nebubox - AI Coding Tools, Safely Contained
+
 
 <p align="center">
   <picture>
@@ -19,6 +19,8 @@
     <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" />
   </a>
 </p>
+
+# Nebubox - AI Coding Tools, Safely Contained
 
 Run AI coding CLI tools safely inside Docker containers.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Running AI coding tools with full permissions is powerful but risky: a single ba
 - **Zero runtime dependencies** — just Node.js and Docker
 - **Non-root containers** — runs as `coder` user (UID 1000) with passwordless sudo
 - **pnpm support** — optional `--pnpm` flag installs pnpm via corepack
+- **Playwright support** — optional `--playwright` flag installs headless browser system dependencies, global CLIs, and configures a persistent host cache
 
 ## Prerequisites
 
@@ -79,6 +80,9 @@ nebubox start ./my-project --tool claude --github
 
 # Start with pnpm available in the container
 nebubox start ./my-project --tool claude --pnpm
+
+# Start with Playwright browser screenshot support
+nebubox start ./my-project --tool claude --playwright
 ```
 
 This will:
@@ -93,12 +97,12 @@ When you exit the shell, the container keeps running. Reconnect anytime with `ne
 
 | Command | Description |
 |---------|-------------|
-| `nebubox start <path> [--tool <name>] [--rebuild] [--github] [--pnpm]` | Create/start container and attach shell |
+| `nebubox start <path> [--tool <name>] [--rebuild] [--github] [--pnpm] [--playwright]` | Create/start container and attach shell |
 | `nebubox list [--tool <name>]` | List managed containers |
 | `nebubox stop <name>` | Stop a running container |
 | `nebubox attach <name>` | Attach to a running container |
 | `nebubox remove <name>` | Remove a container |
-| `nebubox build [<tool>] [--tool <name>] [--rebuild] [--github] [--pnpm]` | Build or rebuild a tool's Docker image |
+| `nebubox build [<tool>] [--tool <name>] [--rebuild] [--github] [--pnpm] [--playwright]` | Build or rebuild a tool's Docker image |
 
 ## Supported Tools
 
@@ -268,6 +272,52 @@ nebubox start ./my-project --tool claude --pnpm --github
 
 ```bash
 nebubox build claude --pnpm
+```
+
+### Playwright Support (`--playwright`)
+
+The `--playwright` flag equips the container with headless browser screenshot and testing capabilities out-of-the-box. It installs system packages for Chromium rendering (including international fonts and `unzip`) and installs Playwright executables globally.
+
+**What it does:**
+
+- Builds a **separate image** tagged `nebubox-<tool>-playwright:latest` (or dynamically combined suffixes, e.g. `nebubox-<tool>-pnpm-playwright-github:latest`)
+- Installs the required Debian graphical, windowing, and font libraries for headless Chromium inside the image at build-time.
+- Installs `unzip` (system package) and `@playwright/test` / `@playwright/cli` globally in the container's user path.
+- Bind-mounts the host directory `~/.nebubox/playwright-cache/` to `/home/coder/.cache/ms-playwright` inside the container. This ensures downloaded browsers survive container reconstructions and are shared across projects.
+
+**Usage:**
+
+```bash
+nebubox start ./my-project --tool claude --playwright
+```
+
+**First-use workflow:**
+
+The first time you start a container with `--playwright`, you must download the Chromium browser binary into the persistent host cache:
+
+```bash
+# 1. Download the Chromium browser (only needed once per host machine)
+playwright install chromium
+
+# 2. (Optional) Install agent skills for playwright-cli
+playwright-cli install --skills
+```
+
+Once installed, you can test it by running:
+```bash
+playwright screenshot https://example.com example.png
+```
+
+**Combined with other options:**
+
+```bash
+nebubox start ./my-project --tool claude --pnpm --playwright --github
+```
+
+**Pre-building the image:**
+
+```bash
+nebubox build claude --playwright
 ```
 
 ## Development

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ description: Run AI coding CLI tools like Claude Code, Gemini CLI, and Codex saf
 - **Auth persistence** — credentials survive across container restarts via shared host directories
 - **Zero runtime dependencies** — just Node.js and Docker
 - **Non-root containers** — runs as `coder` user (UID 1000) with passwordless sudo
+- **Playwright support** — optional `--playwright` flag installs headless browser system dependencies, global CLIs, and configures a persistent host cache
 
 ## Architecture
 
@@ -68,10 +69,11 @@ Containers are named `nebubox-<tool>-<project-dir>` (or `nebubox-<tool>-<project
 ~/.nebubox/
   auth/
     claude/         # Claude Code credentials & config
-    antigravity/    # Antigravity CLI credentials
+    antigravity/    # Antigravity CLI credentials (shared)
     codex/          # Codex CLI credentials
     gemini/         # Gemini CLI credentials
     github/         # GitHub CLI auth + .gitconfig (when --github is used)
+  playwright-cache/ # Playwright browser cache (when --playwright is used)
 ```
 
 ## GitHub CLI Integration
@@ -79,6 +81,21 @@ Containers are named `nebubox-<tool>-<project-dir>` (or `nebubox-<tool>-<project
 Pass `--github` to install [GitHub CLI](https://cli.github.com/) in the container with persistent credentials. After a one-time `gh auth login`, your git identity is automatically configured from your GitHub account, and AI tools can create PRs, push branches, and call the GitHub API from inside the sandbox.
 
 See the [Advanced section in the README](https://github.com/luixaviles/nebubox#advanced) for the full setup guide.
+
+## Playwright Integration
+
+Pass `--playwright` to equip the container with headless browser screenshot and testing capabilities out-of-the-box. Nebubox installs system packages for Chromium rendering (including international fonts and `unzip`) and installs Playwright executables globally.
+
+The first time you start a container with `--playwright`, you should download the Chromium browser binary into the persistent host cache:
+
+```bash
+playwright install chromium
+```
+
+Once installed, you can test it by running:
+```bash
+playwright screenshot https://example.com example.png
+```
 
 ## Links
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import { parseArgs } from './utils/parse-args.js';
 const VERSION = '0.4.0';
 
 const KNOWN_FLAGS = new Set([
-  'tool', 'rebuild', 'github', 'pnpm', 'help', 'h', 'version', 'v',
+  'tool', 'rebuild', 'github', 'pnpm', 'playwright', 'help', 'h', 'version', 'v',
 ]);
 
 function printHelp(): void {
@@ -26,12 +26,12 @@ USAGE
   nebubox <command> [options]
 
 COMMANDS
-  start <path> [--tool <name>] [--rebuild] [--github] [--pnpm]   Create/start container and attach shell
+  start <path> [--tool <name>] [--rebuild] [--github] [--pnpm] [--playwright]  Create/start container and attach shell
   list [--tool <name>]           List managed containers
   stop <name>                    Stop a running container
   attach <name>                  Attach to a running container
   remove <name>                  Remove a container
-  build [<tool>] [--tool <name>] [--rebuild] [--github] [--pnpm]   Build (or rebuild) a tool's Docker image
+  build [<tool>] [--tool <name>] [--rebuild] [--github] [--pnpm] [--playwright]  Build (or rebuild) a tool's Docker image
 
 OPTIONS
   --tool <name>    Tool to use (interactive prompt if omitted)
@@ -39,6 +39,7 @@ OPTIONS
   --rebuild        Rebuild image (no Docker cache) and recreate container
   --github         Install GitHub CLI and persist auth across sessions
   --pnpm           Install pnpm package manager via corepack
+  --playwright     Install Playwright system dependencies and configure persistent host cache
   --help, -h       Show this help message
   --version, -v    Show version
 
@@ -96,7 +97,14 @@ export async function main(): Promise<void> {
           process.exit(1);
         }
         const startTool = flags['tool'] ?? await promptToolSelection();
-        await startCommand({ path, tool: startTool, rebuild: flags['rebuild'] === 'true', github: flags['github'] === 'true', pnpm: flags['pnpm'] === 'true' });
+        await startCommand({
+          path,
+          tool: startTool,
+          rebuild: flags['rebuild'] === 'true',
+          github: flags['github'] === 'true',
+          pnpm: flags['pnpm'] === 'true',
+          playwright: flags['playwright'] === 'true',
+        });
         break;
       }
 
@@ -140,7 +148,13 @@ export async function main(): Promise<void> {
 
       case 'build': {
         const buildTool = args[0] ?? flags['tool'] ?? await promptToolSelection();
-        await buildCommand({ tool: buildTool, rebuild: flags['rebuild'] === 'true', github: flags['github'] === 'true', pnpm: flags['pnpm'] === 'true' });
+        await buildCommand({
+          tool: buildTool,
+          rebuild: flags['rebuild'] === 'true',
+          github: flags['github'] === 'true',
+          pnpm: flags['pnpm'] === 'true',
+          playwright: flags['playwright'] === 'true',
+        });
         break;
       }
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -8,6 +8,7 @@ export interface BuildOptions {
   rebuild: boolean;
   github: boolean;
   pnpm: boolean;
+  playwright: boolean;
 }
 
 export async function buildCommand(opts: BuildOptions): Promise<void> {
@@ -19,6 +20,7 @@ export async function buildCommand(opts: BuildOptions): Promise<void> {
   const imageOpts: ImageOptions = {};
   if (opts.github) imageOpts.github = true;
   if (opts.pnpm) imageOpts.pnpm = true;
+  if (opts.playwright) imageOpts.playwright = true;
 
   if (imageExists(profile.name, imageOpts)) {
     log.info(`Image ${getImageName(profile.name, imageOpts)} already exists. Rebuilding...`);

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -22,6 +22,7 @@ export interface StartOptions {
   rebuild: boolean;
   github: boolean;
   pnpm: boolean;
+  playwright: boolean;
 }
 
 export async function startCommand(opts: StartOptions): Promise<void> {
@@ -33,7 +34,12 @@ export async function startCommand(opts: StartOptions): Promise<void> {
   const imageOpts: ImageOptions = {};
   if (opts.github) imageOpts.github = true;
   if (opts.pnpm) imageOpts.pnpm = true;
-  const containerName = getContainerName(profile.name, projectPath, { github: opts.github, pnpm: opts.pnpm });
+  if (opts.playwright) imageOpts.playwright = true;
+  const containerName = getContainerName(profile.name, projectPath, {
+    github: opts.github,
+    pnpm: opts.pnpm,
+    playwright: opts.playwright,
+  });
 
   // Ensure image exists
   if (!imageExists(profile.name, imageOpts)) {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -4,6 +4,8 @@ export const LABEL_PROJECT = 'nebubox.project';
 export const LABEL_PROJECT_PATH = 'nebubox.project-path';
 export const LABEL_GITHUB = 'nebubox.github';
 export const LABEL_PNPM = 'nebubox.pnpm';
+export const LABEL_PLAYWRIGHT = 'nebubox.playwright';
+
 
 export const IMAGE_PREFIX = 'nebubox-';
 export const CONTAINER_PREFIX = 'nebubox-';

--- a/src/docker/container.test.ts
+++ b/src/docker/container.test.ts
@@ -11,7 +11,7 @@ import {
   listContainers,
   getContainerImage,
 } from './container.js';
-import { CONTAINER_PREFIX, CODER_HOME, LABEL_MANAGED, LABEL_TOOL, LABEL_GITHUB, LABEL_PNPM } from '../config/constants.js';
+import { CONTAINER_PREFIX, CODER_HOME, LABEL_MANAGED, LABEL_TOOL, LABEL_GITHUB, LABEL_PNPM, LABEL_PLAYWRIGHT } from '../config/constants.js';
 import { ContainerError } from '../utils/errors.js';
 import type { ToolProfile } from '../config/tools.js';
 import { TOOL_PROFILES } from '../config/tools.js';
@@ -22,9 +22,10 @@ vi.mock('./client.js', () => ({
 }));
 
 vi.mock('./image.js', () => ({
-  getImageName: vi.fn((tool: string, options?: { github?: boolean; pnpm?: boolean }) => {
+  getImageName: vi.fn((tool: string, options?: { github?: boolean; pnpm?: boolean; playwright?: boolean }) => {
     let suffix = '';
     if (options?.pnpm) suffix += '-pnpm';
+    if (options?.playwright) suffix += '-playwright';
     if (options?.github) suffix += '-github';
     return `nebubox-${tool}${suffix}:latest`;
   }),
@@ -33,11 +34,13 @@ vi.mock('./image.js', () => ({
 vi.mock('node:fs', () => ({
   existsSync: vi.fn(() => false),
   writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
 }));
 
 vi.mock('../config/paths.js', () => ({
   ensureAuthDir: vi.fn((name: string) => `/tmp/fake-auth-dir/${name}`),
   ensureAuthFile: vi.fn((name: string) => `/tmp/fake-auth/${name}`),
+  getNebuboxHome: vi.fn(() => '/tmp/fake-nebubox-home'),
 }));
 
 import { dockerExec, dockerInteractive } from './client.js';
@@ -81,13 +84,21 @@ describe('getContainerName', () => {
   it('appends -pnpm-github suffix when both are true', () => {
     expect(getContainerName('claude', '/home/user/my-project', { pnpm: true, github: true })).toBe(`${CONTAINER_PREFIX}claude-my-project-pnpm-github`);
   });
+
+  it('appends -playwright suffix when playwright is true', () => {
+    expect(getContainerName('claude', '/home/user/my-project', { playwright: true })).toBe(`${CONTAINER_PREFIX}claude-my-project-playwright`);
+  });
+
+  it('appends -pnpm-playwright-github suffix when all are true', () => {
+    expect(getContainerName('claude', '/home/user/my-project', { pnpm: true, playwright: true, github: true })).toBe(`${CONTAINER_PREFIX}claude-my-project-pnpm-playwright-github`);
+  });
 });
 
 describe('containerExists', () => {
   it('returns ContainerInfo when container is found', () => {
     vi.mocked(dockerExec).mockReturnValue({
       status: 0,
-      stdout: 'nebubox-claude-proj\tUp 2 hours\tclaude\tproj\t/home/user/proj\tfalse\tfalse',
+      stdout: 'nebubox-claude-proj\tUp 2 hours\tclaude\tproj\t/home/user/proj\tfalse\tfalse\tfalse',
       stderr: '',
     });
 
@@ -100,6 +111,7 @@ describe('containerExists', () => {
       projectPath: '/home/user/proj',
       github: 'false',
       pnpm: 'false',
+      playwright: 'false',
     });
   });
 
@@ -134,6 +146,14 @@ describe('containerExists', () => {
     expect(format).toBeDefined();
   });
 
+  it('queries the nebubox.playwright label', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: '', stderr: '' });
+    containerExists('test');
+    const args = vi.mocked(dockerExec).mock.calls[0][0];
+    const format = args.find((a: string) => a.includes('nebubox.playwright'));
+    expect(format).toBeDefined();
+  });
+
   it('returns pnpm false for old containers without pnpm label', () => {
     vi.mocked(dockerExec).mockReturnValue({
       status: 0,
@@ -143,6 +163,17 @@ describe('containerExists', () => {
     const info = containerExists('nebubox-claude-proj');
     expect(info).not.toBeNull();
     expect(info!.pnpm).toBe('false');
+  });
+
+  it('returns playwright false for old containers without playwright label', () => {
+    vi.mocked(dockerExec).mockReturnValue({
+      status: 0,
+      stdout: 'nebubox-claude-proj\tUp 2 hours\tclaude\tproj\t/home/user/proj\tfalse\tfalse\t',
+      stderr: '',
+    });
+    const info = containerExists('nebubox-claude-proj');
+    expect(info).not.toBeNull();
+    expect(info!.playwright).toBe('false');
   });
 });
 
@@ -218,6 +249,29 @@ describe('createContainer', () => {
     createContainer(mockProfile, '/home/user/proj', { pnpm: true });
     const args = vi.mocked(dockerExec).mock.calls[0][0];
     expect(args).toContain(`${LABEL_PNPM}=true`);
+  });
+
+  it('sets nebubox.playwright label to false when playwright is not enabled', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: 'abc', stderr: '' });
+    createContainer(mockProfile, '/home/user/proj');
+    const args = vi.mocked(dockerExec).mock.calls[0][0];
+    expect(args).toContain(`${LABEL_PLAYWRIGHT}=false`);
+  });
+
+  it('sets nebubox.playwright label to true when playwright is enabled', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: 'abc', stderr: '' });
+    createContainer(mockProfile, '/home/user/proj', { playwright: true });
+    const args = vi.mocked(dockerExec).mock.calls[0][0];
+    expect(args).toContain(`${LABEL_PLAYWRIGHT}=true`);
+  });
+
+  it('mounts playwright-cache to /home/coder/.cache/ms-playwright when playwright is enabled', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: 'abc', stderr: '' });
+    createContainer(mockProfile, '/home/user/proj', { playwright: true });
+    const args = vi.mocked(dockerExec).mock.calls[0][0];
+    const vArgs = args.filter((_: string, i: number) => args[i - 1] === '-v');
+    const cacheMount = vArgs.find((v: string) => v.includes('/.cache/ms-playwright'));
+    expect(cacheMount).toBeDefined();
   });
 });
 
@@ -367,7 +421,7 @@ describe('listContainers', () => {
   it('returns parsed container list', () => {
     vi.mocked(dockerExec).mockReturnValue({
       status: 0,
-      stdout: 'c1\tUp\tclaude\tproj1\t/p1\tfalse\tfalse\nc2\tExited\tgemini\tproj2\t/p2\ttrue\tfalse',
+      stdout: 'c1\tUp\tclaude\tproj1\t/p1\tfalse\tfalse\tfalse\nc2\tExited\tgemini\tproj2\t/p2\ttrue\tfalse\tfalse',
       stderr: '',
     });
 
@@ -381,6 +435,7 @@ describe('listContainers', () => {
       projectPath: '/p1',
       github: 'false',
       pnpm: 'false',
+      playwright: 'false',
     });
     expect(list[1]).toEqual({
       name: 'c2',
@@ -390,6 +445,7 @@ describe('listContainers', () => {
       projectPath: '/p2',
       github: 'true',
       pnpm: 'false',
+      playwright: 'false',
     });
   });
 
@@ -434,6 +490,14 @@ describe('listContainers', () => {
     listContainers();
     const args = vi.mocked(dockerExec).mock.calls[0][0];
     const format = args.find((a: string) => a.includes('nebubox.pnpm'));
+    expect(format).toBeDefined();
+  });
+
+  it('queries the nebubox.playwright label', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: '', stderr: '' });
+    listContainers();
+    const args = vi.mocked(dockerExec).mock.calls[0][0];
+    const format = args.find((a: string) => a.includes('nebubox.playwright'));
     expect(format).toBeDefined();
   });
 });

--- a/src/docker/container.ts
+++ b/src/docker/container.ts
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync } from 'node:fs';
+import { existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import type { ToolProfile } from '../config/tools.js';
 import {
@@ -9,10 +9,11 @@ import {
   LABEL_PROJECT_PATH,
   LABEL_GITHUB,
   LABEL_PNPM,
+  LABEL_PLAYWRIGHT,
   CODER_HOME,
   WORKSPACE_DIR,
 } from '../config/constants.js';
-import { ensureAuthDir, ensureAuthFile } from '../config/paths.js';
+import { ensureAuthDir, ensureAuthFile, getNebuboxHome } from '../config/paths.js';
 import { dockerExec, dockerInteractive } from './client.js';
 import { getImageName } from './image.js';
 import { ContainerError } from '../utils/errors.js';
@@ -20,6 +21,7 @@ import { ContainerError } from '../utils/errors.js';
 export interface ContainerOptions {
   github?: boolean;
   pnpm?: boolean;
+  playwright?: boolean;
 }
 
 export interface ContainerInfo {
@@ -30,13 +32,15 @@ export interface ContainerInfo {
   projectPath: string;
   github: string;
   pnpm: string;
+  playwright: string;
 }
 
-// Suffixes appended in fixed order: -pnpm before -github
+// Suffixes appended in fixed order: -pnpm before -playwright before -github
 export function getContainerName(toolName: string, projectPath: string, options?: ContainerOptions): string {
   const projectBasename = basename(projectPath);
   let suffix = '';
   if (options?.pnpm) suffix += '-pnpm';
+  if (options?.playwright) suffix += '-playwright';
   if (options?.github) suffix += '-github';
   return `${CONTAINER_PREFIX}${toolName}-${projectBasename}${suffix}`;
 }
@@ -45,7 +49,7 @@ export function containerExists(name: string): ContainerInfo | null {
   const result = dockerExec([
     'ps', '-a',
     '--filter', `name=^/${name}$`,
-    '--format', '{{.Names}}\t{{.Status}}\t{{.Label "nebubox.tool"}}\t{{.Label "nebubox.project"}}\t{{.Label "nebubox.project-path"}}\t{{.Label "nebubox.github"}}\t{{.Label "nebubox.pnpm"}}',
+    '--format', '{{.Names}}\t{{.Status}}\t{{.Label "nebubox.tool"}}\t{{.Label "nebubox.project"}}\t{{.Label "nebubox.project-path"}}\t{{.Label "nebubox.github"}}\t{{.Label "nebubox.pnpm"}}\t{{.Label "nebubox.playwright"}}',
   ]);
 
   if (result.status !== 0 || !result.stdout) {
@@ -63,6 +67,7 @@ export function containerExists(name: string): ContainerInfo | null {
     projectPath: parts[4],
     github: parts[5],
     pnpm: parts[6] || 'false',
+    playwright: parts[7] || 'false',
   };
 }
 
@@ -83,8 +88,9 @@ export function createContainer(
 ): string {
   const github = options?.github ?? false;
   const pnpm = options?.pnpm ?? false;
-  const name = getContainerName(profile.name, projectPath, { github, pnpm });
-  const imageName = getImageName(profile.name, { github, pnpm });
+  const playwright = options?.playwright ?? false;
+  const name = getContainerName(profile.name, projectPath, { github, pnpm, playwright });
+  const imageName = getImageName(profile.name, { github, pnpm, playwright });
   const hostAuthDir = ensureAuthDir(profile.name);
   const containerAuthDir = `${CODER_HOME}/${profile.authDir}`;
   const projectBasename = basename(projectPath);
@@ -98,6 +104,7 @@ export function createContainer(
     '--label', `${LABEL_PROJECT_PATH}=${projectPath}`,
     '--label', `${LABEL_GITHUB}=${github}`,
     '--label', `${LABEL_PNPM}=${pnpm}`,
+    '--label', `${LABEL_PLAYWRIGHT}=${playwright}`,
     '-it',
     '-v', `${projectPath}:${WORKSPACE_DIR}`,
     '-v', `${hostAuthDir}:${containerAuthDir}`,
@@ -121,6 +128,13 @@ export function createContainer(
     if (!existsSync(gitconfigPath)) {
       writeFileSync(gitconfigPath, '');
     }
+  }
+
+  // Playwright: mount host browser cache
+  if (playwright) {
+    const hostPlaywrightCache = join(getNebuboxHome(), 'playwright-cache');
+    mkdirSync(hostPlaywrightCache, { recursive: true });
+    createArgs.push('-v', `${hostPlaywrightCache}:${CODER_HOME}/.cache/ms-playwright`);
   }
 
   createArgs.push('-w', WORKSPACE_DIR, imageName);
@@ -171,7 +185,7 @@ export function listContainers(toolFilter?: string): ContainerInfo[] {
 
   args.push(
     '--format',
-    '{{.Names}}\t{{.Status}}\t{{.Label "nebubox.tool"}}\t{{.Label "nebubox.project"}}\t{{.Label "nebubox.project-path"}}\t{{.Label "nebubox.github"}}\t{{.Label "nebubox.pnpm"}}',
+    '{{.Names}}\t{{.Status}}\t{{.Label "nebubox.tool"}}\t{{.Label "nebubox.project"}}\t{{.Label "nebubox.project-path"}}\t{{.Label "nebubox.github"}}\t{{.Label "nebubox.pnpm"}}\t{{.Label "nebubox.playwright"}}',
   );
 
   const result = dockerExec(args);
@@ -190,6 +204,7 @@ export function listContainers(toolFilter?: string): ContainerInfo[] {
       projectPath: parts[4],
       github: parts[5],
       pnpm: parts[6] || 'false',
+      playwright: parts[7] || 'false',
     };
   });
 }

--- a/src/docker/image.test.ts
+++ b/src/docker/image.test.ts
@@ -40,6 +40,14 @@ describe('getImageName', () => {
     expect(getImageName('claude', { pnpm: true })).toBe(`${IMAGE_PREFIX}claude-pnpm:latest`);
   });
 
+  it('appends -playwright suffix when playwright is true', () => {
+    expect(getImageName('claude', { playwright: true })).toBe(`${IMAGE_PREFIX}claude-playwright:latest`);
+  });
+
+  it('appends -pnpm-playwright-github suffix when all are true', () => {
+    expect(getImageName('claude', { pnpm: true, playwright: true, github: true })).toBe(`${IMAGE_PREFIX}claude-pnpm-playwright-github:latest`);
+  });
+
   it('appends -pnpm-github suffix when both are true', () => {
     expect(getImageName('claude', { pnpm: true, github: true })).toBe(`${IMAGE_PREFIX}claude-pnpm-github:latest`);
   });
@@ -204,6 +212,39 @@ describe('generateDockerfile with pnpm', () => {
     expect(enableIndex).toBeLessThan(userIndex);
     expect(ghIndex).toBeLessThan(userIndex);
     expect(prepareIndex).toBeGreaterThan(userIndex);
+  });
+});
+
+describe('generateDockerfile with playwright', () => {
+  it('includes playwright install-deps and unzip when playwright is true', () => {
+    const df = generateDockerfile(mockProfile, { playwright: true });
+    expect(df).toContain('npx playwright install-deps chromium');
+    expect(df).toContain('apt-get install -y --no-install-recommends unzip');
+    expect(df).toContain('npm install -g @playwright/test @playwright/cli');
+  });
+
+  it('does not include playwright install-deps when playwright is not set', () => {
+    const df = generateDockerfile(mockProfile);
+    expect(df).not.toContain('playwright install-deps');
+    expect(df).not.toContain('unzip');
+    expect(df).not.toContain('@playwright/test');
+    expect(df).not.toContain('@playwright/cli');
+  });
+
+  it('runs install-deps and unzip as root before USER coder', () => {
+    const df = generateDockerfile(mockProfile, { playwright: true });
+    const installIndex = df.indexOf('npx playwright install-deps chromium');
+    const userIndex = df.indexOf(`USER ${CODER_USER}`);
+    expect(installIndex).toBeGreaterThan(-1);
+    expect(installIndex).toBeLessThan(userIndex);
+  });
+
+  it('runs npm install -g @playwright/test @playwright/cli as coder user after USER coder', () => {
+    const df = generateDockerfile(mockProfile, { playwright: true });
+    const installIndex = df.indexOf('npm install -g @playwright/test @playwright/cli');
+    const userIndex = df.indexOf(`USER ${CODER_USER}`);
+    expect(installIndex).toBeGreaterThan(-1);
+    expect(installIndex).toBeGreaterThan(userIndex);
   });
 });
 

--- a/src/docker/image.ts
+++ b/src/docker/image.ts
@@ -20,12 +20,14 @@ import { GH_SETUP_SCRIPT, GH_BASHRC_HOOK } from '../github/setup-script.js';
 export interface ImageOptions {
   github?: boolean;
   pnpm?: boolean;
+  playwright?: boolean;
 }
 
-// Suffixes appended in fixed order: -pnpm before -github
+// Suffixes appended in fixed order: -pnpm before -playwright before -github
 export function getImageName(toolName: string, options?: ImageOptions): string {
   let suffix = '';
   if (options?.pnpm) suffix += '-pnpm';
+  if (options?.playwright) suffix += '-playwright';
   if (options?.github) suffix += '-github';
   return `${IMAGE_PREFIX}${toolName}${suffix}:latest`;
 }
@@ -34,6 +36,7 @@ export function generateDockerfile(profile: ToolProfile, options?: ImageOptions)
   const lines: string[] = [];
   const github = options?.github ?? false;
   const pnpm = options?.pnpm ?? false;
+  const playwright = options?.playwright ?? false;
 
   lines.push(`FROM ${BASE_IMAGE}`);
   lines.push('');
@@ -68,6 +71,14 @@ export function generateDockerfile(profile: ToolProfile, options?: ImageOptions)
     lines.push('');
   }
 
+  // Playwright: install unzip and Chromium system dependencies (must run as root, before USER coder)
+  if (playwright) {
+    lines.push('RUN apt-get update && apt-get install -y --no-install-recommends unzip \\');
+    lines.push('    && npx playwright install-deps chromium \\');
+    lines.push('    && rm -rf /var/lib/apt/lists/*');
+    lines.push('');
+  }
+
   // Non-root user (handles pre-existing GID/UID in base image)
   lines.push(`RUN groupadd --gid ${CODER_GID} ${CODER_USER} 2>/dev/null || true \\`);
   lines.push(`    && (useradd --uid ${CODER_UID} --gid ${CODER_GID} --shell /bin/bash --create-home ${CODER_USER} 2>/dev/null \\`);
@@ -95,6 +106,12 @@ export function generateDockerfile(profile: ToolProfile, options?: ImageOptions)
   lines.push(`ARG NPM_CONFIG_PREFIX="${CODER_HOME}/.npm-global"`);
   lines.push(`ENV PATH="${CODER_HOME}/.npm-global/bin:$PATH"`);
   lines.push('');
+
+  // Playwright: install global CLI for coder user
+  if (playwright) {
+    lines.push('RUN npm install -g @playwright/test @playwright/cli');
+    lines.push('');
+  }
 
   // pnpm: download and cache as coder user (cache lands in ~/.cache/node/corepack/)
   if (pnpm) {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -134,7 +134,7 @@ describe('main CLI functionality', () => {
 
   it('starts command with path and flags', async () => {
     const { startCommand } = await import('./commands/start.js');
-    process.argv = ['node', 'nebubox', 'start', './my-path', '--tool', 'claude', '--rebuild', 'true', '--github', 'true', '--pnpm', 'true'];
+    process.argv = ['node', 'nebubox', 'start', './my-path', '--tool', 'claude', '--rebuild', 'true', '--github', 'true', '--pnpm', 'true', '--playwright', 'true'];
     await main();
     expect(startCommand).toHaveBeenCalledWith({
       path: './my-path',
@@ -142,6 +142,7 @@ describe('main CLI functionality', () => {
       rebuild: true,
       github: true,
       pnpm: true,
+      playwright: true,
     });
   });
 
@@ -158,6 +159,7 @@ describe('main CLI functionality', () => {
       rebuild: false,
       github: false,
       pnpm: false,
+      playwright: false,
     });
   });
 
@@ -209,13 +211,14 @@ describe('main CLI functionality', () => {
 
   it('builds command with tool and flags', async () => {
     const { buildCommand } = await import('./commands/build.js');
-    process.argv = ['node', 'nebubox', 'build', 'claude', '--rebuild', 'true', '--github', 'true', '--pnpm', 'true'];
+    process.argv = ['node', 'nebubox', 'build', 'claude', '--rebuild', 'true', '--github', 'true', '--pnpm', 'true', '--playwright', 'true'];
     await main();
     expect(buildCommand).toHaveBeenCalledWith({
       tool: 'claude',
       rebuild: true,
       github: true,
       pnpm: true,
+      playwright: true,
     });
   });
 
@@ -231,6 +234,7 @@ describe('main CLI functionality', () => {
       rebuild: false,
       github: false,
       pnpm: false,
+      playwright: false,
     });
   });
 


### PR DESCRIPTION
### Summary
This PR adds `--playwright` flag support to `start` and `build` commands.

### Changes
* Installs Playwright system browser dependencies and global npm packages (`@playwright/test` and `@playwright/cli`) inside the Docker container.
* Sets up a persistent cache mounting host's `~/.nebubox/playwright-cache` to `/home/coder/.cache/ms-playwright` inside the container to avoid downloading browser binaries multiple times.