### PR TITLE
fix(antigravity): mount entire .gemini directory to prevent permission denied

### DIFF
--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -66,7 +66,7 @@ const antigravity: ToolProfile = {
   envVars: {
     PATH: '/home/coder/.local/bin:$PATH',
   },
-  authDir: '.gemini/antigravity-cli',
+  authDir: '.gemini',
   authFiles: [],
   hint: 'Run `agy --dangerously-skip-permissions` to start Antigravity CLI.',
 };


### PR DESCRIPTION
### Summary
This PR changes the `authDir` for the `antigravity` CLI profile from `.gemini/antigravity-cli` to `.gemini`.

### Reason
When mounting a subdirectory like `/home/coder/.gemini/antigravity-cli` inside the container when `/home/coder/.gemini` does not exist in the base image, Docker automatically creates the parent `/home/coder/.gemini` folder as `root:root`. Because of this, the `coder` user (UID 1000) inside the container gets a permission denied error when attempting to create the sibling config directory at `/home/coder/.gemini/config/`. Mounting the entire `.gemini` folder directly ensures it is owned by the container user (UID 1000), resolving the permission issues.