### PR TITLE
Add ability to define mounts during start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Added a repeatable `--mount <host-path>[:<dest>][:ro|rw]` flag to `nebubox start` for exposing additional host paths inside the container. The destination is optional and defaults to `/home/coder/workspace/<host-basename>` (alongside your project); a relative destination is placed under the workspace, an absolute one is used verbatim. Host paths must exist; mounts are applied when the container is first created (use `--rebuild` to change them on an existing container).
+
 ## [0.5.1] - 2026-06-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ nebubox start ./my-project --tool claude --pnpm
 
 # Start with Playwright browser screenshot support
 nebubox start ./my-project --tool claude --playwright
+
+# Mount extra host paths into the container (repeatable)
+nebubox start ./my-project --tool claude --mount ~/shared-data
 ```
 
 This will:
@@ -99,7 +102,7 @@ When you exit the shell, the container keeps running. Reconnect anytime with `ne
 
 | Command | Description |
 |---------|-------------|
-| `nebubox start <path> [--tool <name>] [--rebuild] [--github] [--pnpm] [--playwright]` | Create/start container and attach shell |
+| `nebubox start <path> [--tool <name>] [--rebuild] [--github] [--pnpm] [--playwright] [--mount <spec>]` | Create/start container and attach shell |
 | `nebubox list [--tool <name>]` | List managed containers |
 | `nebubox stop <name>` | Stop a running container |
 | `nebubox attach <name>` | Attach to a running container |
@@ -321,6 +324,35 @@ nebubox start ./my-project --tool claude --pnpm --playwright --github
 ```bash
 nebubox build claude --playwright
 ```
+
+### Custom Mounts (`--mount`)
+
+By default a container only sees your project directory (at `/home/coder/workspace`) and the tool's auth directory — the rest of the host filesystem stays invisible. Use `--mount` to expose additional host paths inside the container.
+
+The flag takes a spec in the form `<host-path>[:<dest>][:ro|rw]`. The destination is **optional** and defaults to `/home/coder/workspace/<host-basename>` — i.e. alongside your project, right where the shell starts:
+
+- **host path** — a file or directory that must already exist on the host. Relative paths are resolved against the current working directory.
+- **dest** *(optional)* — where to mount it in the container. A bare name (e.g. `renamed.env`) is placed under the workspace (`/home/coder/workspace`); an absolute path (e.g. `/home/coder/.aws` or `/opt/data`) is used verbatim. Omit it to reuse the host basename.
+- **mode** *(optional)* — `ro` (read-only) or `rw` (read-write, the default). When the middle segment is exactly `ro` or `rw` it's interpreted as the mode, not a destination.
+
+It is **repeatable**, so you can add several mounts in one command:
+
+```bash
+# ~/shared-data -> /home/coder/workspace/shared-data
+nebubox start ./my-project --tool claude --mount ~/shared-data
+
+# A data dir alongside the project, and a file mounted read-only under a new name
+nebubox start ./my-project --tool claude \
+  --mount ./fixtures \
+  --mount ~/secrets.env:renamed.env:ro
+
+# Absolute destination for $HOME-relative config that tools expect outside the workspace
+nebubox start ./my-project --tool claude --mount ~/.aws:/home/coder/.aws:ro
+```
+
+> **Note:** The default lands mounts inside the workspace, which is your project directory — they'll appear in `ls` and may show up in `git status`. For credentials/config that tools resolve relative to `$HOME` (e.g. `~/.aws`, `~/.ssh`), give an absolute destination like `/home/coder/.aws`.
+
+> **Note:** Custom mounts are applied when the container is first created. Restarting an existing container reuses its original mounts — pass `--rebuild` to recreate it with a new set of mounts.
 
 ## Development
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import { parseArgs } from './utils/parse-args.js';
 const VERSION = '0.4.0';
 
 const KNOWN_FLAGS = new Set([
-  'tool', 'rebuild', 'github', 'pnpm', 'playwright', 'help', 'h', 'version', 'v',
+  'tool', 'rebuild', 'github', 'pnpm', 'playwright', 'mount', 'help', 'h', 'version', 'v',
 ]);
 
 function printHelp(): void {
@@ -26,7 +26,7 @@ USAGE
   nebubox <command> [options]
 
 COMMANDS
-  start <path> [--tool <name>] [--rebuild] [--github] [--pnpm] [--playwright]  Create/start container and attach shell
+  start <path> [--tool <name>] [--rebuild] [--github] [--pnpm] [--playwright] [--mount <spec>]  Create/start container and attach shell
   list [--tool <name>]           List managed containers
   stop <name>                    Stop a running container
   attach <name>                  Attach to a running container
@@ -40,6 +40,9 @@ OPTIONS
   --github         Install GitHub CLI and persist auth across sessions
   --pnpm           Install pnpm package manager via corepack
   --playwright     Install Playwright system dependencies and configure persistent host cache
+  --mount <spec>   Add an extra bind mount: <host-path>[:<dest>][:ro|rw]
+                   Repeatable; host path must exist. Destination defaults to
+                   the workspace (relative dest is placed under /home/coder/workspace)
   --help, -h       Show this help message
   --version, -v    Show version
 
@@ -47,6 +50,8 @@ EXAMPLES
   nebubox start ./my-project
   nebubox start ./my-project --tool gemini
   nebubox start ./my-project --tool claude --github
+  nebubox start ./my-project --mount ~/data --mount ~/notes.md:ro
+  nebubox start ./my-project --mount ~/.aws:/home/coder/.aws:ro
   nebubox list
   nebubox list --tool claude
   nebubox stop nebubox-claude-my-project
@@ -68,7 +73,7 @@ function warnUnknownFlags(flags: Record<string, string>): void {
 export async function main(): Promise<void> {
   process.title = `nebubox v${VERSION}`;
 
-  const { command, args, flags } = parseArgs(process.argv);
+  const { command, args, flags, multiFlags } = parseArgs(process.argv);
 
   if (flags['help'] || flags['h'] || command === 'help' || command === '-h') {
     printHelp();
@@ -104,6 +109,7 @@ export async function main(): Promise<void> {
           github: flags['github'] === 'true',
           pnpm: flags['pnpm'] === 'true',
           playwright: flags['playwright'] === 'true',
+          mounts: multiFlags['mount'] ?? [],
         });
         break;
       }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -12,7 +12,7 @@ import {
   attachContainer,
   getContainerName,
 } from '../docker/container.js';
-import { ensureDocker, validateProjectPath, validateToolName } from '../utils/validation.js';
+import { ensureDocker, validateProjectPath, validateToolName, validateMount } from '../utils/validation.js';
 import { getAuthDir } from '../config/paths.js';
 import * as log from '../utils/logger.js';
 
@@ -23,11 +23,13 @@ export interface StartOptions {
   github: boolean;
   pnpm: boolean;
   playwright: boolean;
+  mounts: string[];
 }
 
 export async function startCommand(opts: StartOptions): Promise<void> {
   validateToolName(opts.tool);
   const projectPath = validateProjectPath(opts.path);
+  const mounts = opts.mounts.map(validateMount);
   ensureDocker();
 
   const profile = getToolProfile(opts.tool)!;
@@ -63,6 +65,13 @@ export async function startCommand(opts: StartOptions): Promise<void> {
   let existing = containerExists(containerName);
 
   if (existing) {
+    if (mounts.length > 0) {
+      log.warn(
+        `Custom mounts only apply when a container is first created. ` +
+        `Existing container ${containerName} keeps its original mounts; ` +
+        `use --rebuild to recreate it with the new mounts.`,
+      );
+    }
     if (isContainerRunning(containerName)) {
       log.info(`Container ${containerName} is already running. Attaching...`);
     } else {
@@ -72,7 +81,7 @@ export async function startCommand(opts: StartOptions): Promise<void> {
     }
   } else {
     log.step(`Creating container ${containerName}...`);
-    createContainer(profile, projectPath, imageOpts);
+    createContainer(profile, projectPath, { ...imageOpts, mounts });
     startContainer(containerName);
     log.success(`Container ${containerName} created and started.`);
   }

--- a/src/docker/container.test.ts
+++ b/src/docker/container.test.ts
@@ -273,6 +273,33 @@ describe('createContainer', () => {
     const cacheMount = vArgs.find((v: string) => v.includes('/.cache/ms-playwright'));
     expect(cacheMount).toBeDefined();
   });
+
+  it('appends each custom mount as a -v arg', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: 'abc', stderr: '' });
+    createContainer(mockProfile, '/home/user/proj', {
+      mounts: ['/host/a:/home/coder/a', '/host/b:/home/coder/b:ro'],
+    });
+    const args = vi.mocked(dockerExec).mock.calls[0][0];
+    const vArgs = args.filter((_: string, i: number) => args[i - 1] === '-v');
+    expect(vArgs).toContain('/host/a:/home/coder/a');
+    expect(vArgs).toContain('/host/b:/home/coder/b:ro');
+  });
+
+  it('adds no extra -v args when mounts is empty or omitted', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: 'abc', stderr: '' });
+    createContainer(mockProfile, '/home/user/proj', { mounts: [] });
+    const args = vi.mocked(dockerExec).mock.calls[0][0];
+    const vCount = args.filter((a: string) => a === '-v').length;
+    // Only project mount + authDir mount (mockProfile has no authFiles)
+    expect(vCount).toBe(2);
+  });
+
+  it('places custom mounts before the -w working-dir arg', () => {
+    vi.mocked(dockerExec).mockReturnValue({ status: 0, stdout: 'abc', stderr: '' });
+    createContainer(mockProfile, '/home/user/proj', { mounts: ['/host/a:/home/coder/a'] });
+    const args = vi.mocked(dockerExec).mock.calls[0][0];
+    expect(args.indexOf('/host/a:/home/coder/a')).toBeLessThan(args.indexOf('-w'));
+  });
 });
 
 describe('createContainer per provider', () => {

--- a/src/docker/container.ts
+++ b/src/docker/container.ts
@@ -22,6 +22,8 @@ export interface ContainerOptions {
   github?: boolean;
   pnpm?: boolean;
   playwright?: boolean;
+  /** Extra bind mounts in normalized `host:container[:ro|rw]` form (see validateMount). */
+  mounts?: string[];
 }
 
 export interface ContainerInfo {
@@ -135,6 +137,11 @@ export function createContainer(
     const hostPlaywrightCache = join(getNebuboxHome(), 'playwright-cache');
     mkdirSync(hostPlaywrightCache, { recursive: true });
     createArgs.push('-v', `${hostPlaywrightCache}:${CODER_HOME}/.cache/ms-playwright`);
+  }
+
+  // User-supplied bind mounts (already normalized/validated)
+  for (const mount of options?.mounts ?? []) {
+    createArgs.push('-v', mount);
   }
 
   createArgs.push('-w', WORKSPACE_DIR, imageName);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -143,6 +143,26 @@ describe('main CLI functionality', () => {
       github: true,
       pnpm: true,
       playwright: true,
+      mounts: [],
+    });
+  });
+
+  it('passes repeated --mount flags through to startCommand', async () => {
+    const { startCommand } = await import('./commands/start.js');
+    process.argv = [
+      'node', 'nebubox', 'start', './my-path', '--tool', 'claude',
+      '--mount', '/host/a:/home/coder/a',
+      '--mount', '/host/b:/home/coder/b:ro',
+    ];
+    await main();
+    expect(startCommand).toHaveBeenCalledWith({
+      path: './my-path',
+      tool: 'claude',
+      rebuild: false,
+      github: false,
+      pnpm: false,
+      playwright: false,
+      mounts: ['/host/a:/home/coder/a', '/host/b:/home/coder/b:ro'],
     });
   });
 
@@ -160,6 +180,7 @@ describe('main CLI functionality', () => {
       github: false,
       pnpm: false,
       playwright: false,
+      mounts: [],
     });
   });
 

--- a/src/utils/parse-args.test.ts
+++ b/src/utils/parse-args.test.ts
@@ -4,7 +4,7 @@ import { parseArgs } from './parse-args.js';
 describe('parseArgs', () => {
   it('returns empty command and args for no arguments', () => {
     const result = parseArgs(['node', 'nebubox']);
-    expect(result).toEqual({ command: '', args: [], flags: {} });
+    expect(result).toEqual({ command: '', args: [], flags: {}, multiFlags: {} });
   });
 
   it('parses a single command', () => {
@@ -58,5 +58,24 @@ describe('parseArgs', () => {
     expect(result.flags['github']).toBe('true');
     expect(result.flags['rebuild']).toBe('true');
     expect(result.flags['tool']).toBe('claude');
+  });
+
+  it('accumulates repeated flags in multiFlags', () => {
+    const result = parseArgs([
+      'node', 'nebubox', 'start', './proj',
+      '--mount', '/a:/x', '--mount', '/b:/y',
+    ]);
+    expect(result.multiFlags['mount']).toEqual(['/a:/x', '/b:/y']);
+  });
+
+  it('keeps last-wins in flags while collecting all values in multiFlags', () => {
+    const result = parseArgs(['node', 'nebubox', 'start', './proj', '--mount', '/a:/x', '--mount', '/b:/y']);
+    expect(result.flags['mount']).toBe('/b:/y');
+    expect(result.multiFlags['mount']).toEqual(['/a:/x', '/b:/y']);
+  });
+
+  it('records single-occurrence flags in multiFlags too', () => {
+    const result = parseArgs(['node', 'nebubox', 'start', './proj', '--tool', 'claude']);
+    expect(result.multiFlags['tool']).toEqual(['claude']);
   });
 });

--- a/src/utils/parse-args.ts
+++ b/src/utils/parse-args.ts
@@ -1,7 +1,21 @@
-export function parseArgs(argv: string[]): { command: string; args: string[]; flags: Record<string, string> } {
+export function parseArgs(argv: string[]): {
+  command: string;
+  args: string[];
+  flags: Record<string, string>;
+  multiFlags: Record<string, string[]>;
+} {
   const rawArgs = argv.slice(2);
   const positional: string[] = [];
+  // `flags` keeps last-wins semantics for single-value flags (e.g. --tool).
+  // `multiFlags` accumulates every occurrence so repeatable flags (e.g. --mount)
+  // can supply multiple values.
   const flags: Record<string, string> = {};
+  const multiFlags: Record<string, string[]> = {};
+
+  const record = (key: string, value: string): void => {
+    flags[key] = value;
+    (multiFlags[key] ??= []).push(value);
+  };
 
   for (let i = 0; i < rawArgs.length; i++) {
     const arg = rawArgs[i];
@@ -9,10 +23,10 @@ export function parseArgs(argv: string[]): { command: string; args: string[]; fl
       const key = arg.slice(2);
       const next = rawArgs[i + 1];
       if (next && !next.startsWith('--')) {
-        flags[key] = next;
+        record(key, next);
         i++;
       } else {
-        flags[key] = 'true';
+        record(key, 'true');
       }
     } else {
       positional.push(arg);
@@ -22,5 +36,5 @@ export function parseArgs(argv: string[]): { command: string; args: string[]; fl
   const command = positional[0] ?? '';
   const args = positional.slice(1);
 
-  return { command, args, flags };
+  return { command, args, flags, multiFlags };
 }

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { mkdtempSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { validateProjectPath, validateToolName, ensureDocker } from './validation.js';
+import { validateProjectPath, validateToolName, validateMount, ensureDocker } from './validation.js';
 import { ValidationError, DockerNotFoundError } from './errors.js';
 
 vi.mock('node:child_process', () => ({
@@ -52,6 +52,64 @@ describe('validateToolName', () => {
       expect((e as Error).message).toContain('codex');
       expect((e as Error).message).toContain('antigravity');
     }
+  });
+});
+
+describe('validateMount', () => {
+  it('defaults the container path to /home/coder/workspace/<basename> when only a host is given', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'nebubox-vm-'));
+    expect(validateMount(dir)).toBe(`${dir}:/home/coder/workspace/${basename(dir)}`);
+  });
+
+  it('treats a lone ro/rw second segment as the mode, keeping the default destination', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'nebubox-vm-'));
+    expect(validateMount(`${dir}:ro`)).toBe(`${dir}:/home/coder/workspace/${basename(dir)}:ro`);
+    expect(validateMount(`${dir}:rw`)).toBe(`${dir}:/home/coder/workspace/${basename(dir)}:rw`);
+  });
+
+  it('places a relative destination under /home/coder/workspace (rename shorthand)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'nebubox-vm-'));
+    const file = join(dir, 'secrets.env');
+    writeFileSync(file, 'x');
+    expect(validateMount(`${file}:renamed.env`)).toBe(`${file}:/home/coder/workspace/renamed.env`);
+    expect(validateMount(`${file}:renamed.env:ro`)).toBe(`${file}:/home/coder/workspace/renamed.env:ro`);
+  });
+
+  it('uses an absolute destination verbatim', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'nebubox-vm-'));
+    expect(validateMount(`${dir}:/opt/data`)).toBe(`${dir}:/opt/data`);
+    expect(validateMount(`${dir}:/home/coder/data:ro`)).toBe(`${dir}:/home/coder/data:ro`);
+  });
+
+  it('resolves a relative host path to absolute', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'nebubox-vm-'));
+    const result = validateMount(`${dir}:/home/coder/data`);
+    expect(result.startsWith('/')).toBe(true);
+  });
+
+  it('accepts an existing host file (not just directories)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'nebubox-vm-'));
+    const file = join(dir, 'creds.json');
+    writeFileSync(file, '{}');
+    expect(validateMount(`${file}:ro`)).toBe(`${file}:/home/coder/workspace/creds.json:ro`);
+  });
+
+  it('throws when there are too many segments', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'nebubox-vm-'));
+    expect(() => validateMount(`${dir}:/home/coder/data:ro:extra`)).toThrow(ValidationError);
+  });
+
+  it('throws for an invalid mode', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'nebubox-vm-'));
+    expect(() => validateMount(`${dir}:/home/coder/data:readonly`)).toThrow(ValidationError);
+  });
+
+  it('throws for an empty spec (missing host path)', () => {
+    expect(() => validateMount('')).toThrow(ValidationError);
+  });
+
+  it('throws when the host path does not exist', () => {
+    expect(() => validateMount('/does/not/exist:/home/coder/data')).toThrow(ValidationError);
   });
 });
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,7 +1,8 @@
 import { existsSync, statSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { basename, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { getToolNames } from '../config/tools.js';
+import { WORKSPACE_DIR } from '../config/constants.js';
 import { DockerNotFoundError, ValidationError } from './errors.js';
 
 export function validateProjectPath(inputPath: string): string {
@@ -23,6 +24,75 @@ export function validateToolName(name: string): void {
       `Unknown tool "${name}". Available tools: ${valid.join(', ')}`
     );
   }
+}
+
+/**
+ * Validates and normalizes a `--mount` spec into a `docker create -v` value.
+ *
+ * Accepted forms (the container path defaults to `/home/coder/workspace/<host-basename>`,
+ * i.e. alongside your project):
+ *   host                        -> host:/home/coder/workspace/<basename>
+ *   host:ro | host:rw           -> host:/home/coder/workspace/<basename>:<mode>
+ *   host:dest                   -> host:/home/coder/workspace/dest   (relative dest)
+ *   host:/abs/dest              -> host:/abs/dest                    (absolute dest, verbatim)
+ *   host:dest:ro                -> host:/home/coder/workspace/dest:ro
+ *
+ * The second segment is treated as the mode only when it is exactly `ro`/`rw`;
+ * otherwise it is a destination. Relative host paths are resolved to absolute,
+ * and the host path must exist.
+ */
+export function validateMount(spec: string): string {
+  const parts = spec.split(':');
+  if (parts.length > 3) {
+    throw new ValidationError(
+      `Invalid mount "${spec}". Expected format: <host-path>[:<container-path>][:ro|rw]`
+    );
+  }
+
+  const hostPart = parts[0];
+  if (!hostPart) {
+    throw new ValidationError(`Invalid mount "${spec}": missing host path`);
+  }
+
+  let destPart: string | undefined;
+  let mode: string | undefined;
+
+  if (parts.length === 3) {
+    destPart = parts[1];
+    mode = parts[2];
+  } else if (parts.length === 2) {
+    // A lone second segment is a mode only when it's exactly ro/rw.
+    if (parts[1] === 'ro' || parts[1] === 'rw') {
+      mode = parts[1];
+    } else {
+      destPart = parts[1];
+    }
+  }
+
+  if (mode !== undefined && mode !== 'ro' && mode !== 'rw') {
+    throw new ValidationError(
+      `Invalid mount "${spec}": mode must be "ro" or "rw", got "${mode}"`
+    );
+  }
+
+  const resolvedHost = resolve(hostPart);
+  if (!existsSync(resolvedHost)) {
+    throw new ValidationError(`Mount host path does not exist: ${resolvedHost}`);
+  }
+
+  // Default to /home/coder/workspace/<host-basename> (alongside the project);
+  // a relative destination is placed under the workspace, an absolute one is
+  // used as-is.
+  let containerPath: string;
+  if (!destPart) {
+    containerPath = `${WORKSPACE_DIR}/${basename(resolvedHost)}`;
+  } else if (destPart.startsWith('/')) {
+    containerPath = destPart;
+  } else {
+    containerPath = `${WORKSPACE_DIR}/${destPart}`;
+  }
+
+  return mode ? `${resolvedHost}:${containerPath}:${mode}` : `${resolvedHost}:${containerPath}`;
 }
 
 export function ensureDocker(): void {


### PR DESCRIPTION
Add --mount support to nebubox start

Why: nebubox start only ever mounted the project directory and the tool's auth files, with no way to expose additional host paths to the container. Anything else a session needed, such as other repositories in other directories, was inaccessible. This is particularly helpful on MacOS where `mount --bind` does not exist and there is not another well supported, secure way to do it.

What changed:
- Added a repeatable --mount <host-path>[:<dest>][:ro|rw] flag to nebubox start.
- The destination is optional and defaults to /home/coder/workspace/<host-basename> (alongside the project). A relative dest is placed under the workspace; an absolute dest (e.g. /home/coder/.aws) is used verbatim. The middle segment is treated as the mode only when it's exactly ro/rw.
- Host paths are validated (must exist; resolved to absolute) via a new validateMount helper, and parseArgs now accumulates repeated flags so --mount can be given multiple times.
- Mounts are applied at container creation; starting an existing container warns that --rebuild is needed to change them.
- Updated help text, README, and CHANGELOG; added unit tests for parsing, validation (all shorthand forms), and the container -v wiring.